### PR TITLE
Merging Govobj.verifyaddress - fix for verifyAddress.

### DIFF
--- a/lib/govobject/govobject.js
+++ b/lib/govobject/govobject.js
@@ -180,12 +180,12 @@ GovObject.prototype._verifyPayment = function(payment) {
     return Boolean((parsedPayment <= 0));
 };
 
-GovObject.prototype._verifyAddress = function(address) {
-    return address.length > 26;
+GovObject.prototype._verifyAddress = function(address, network) {
+    // return address.length > 26;
     // - disable full check until checksum bug in Ubuntu Firefox is fixed
 
-    // var validAddress = Address.isValid(address, network);
-    // return validAddress;
+    var validAddress = Address.isValid(address, network);
+    return validAddress;
 };
 
 GovObject.prototype._verifyUrl = function(url) {

--- a/lib/govobject/govobject.js
+++ b/lib/govobject/govobject.js
@@ -181,11 +181,7 @@ GovObject.prototype._verifyPayment = function(payment) {
 };
 
 GovObject.prototype._verifyAddress = function(address, network) {
-    // return address.length > 26;
-    // - disable full check until checksum bug in Ubuntu Firefox is fixed
-
-    var validAddress = Address.isValid(address, network);
-    return validAddress;
+    return Address.isValid(address, network);
 };
 
 GovObject.prototype._verifyUrl = function(url) {

--- a/lib/govobject/types/proposal.js
+++ b/lib/govobject/types/proposal.js
@@ -134,8 +134,8 @@ Proposal.prototype.getSerializationError = function(opts) {
         return new errors.GovObject.Proposal.invalidDateWindow();
     }
 
-    // verify address (only verifies length > 26)
-    if (!this._verifyAddress(this.payment_address)) {
+    // verify address
+    if (!this._verifyAddress(this.payment_address, this.network)) {
         return new errors.GovObject.Proposal.invalidAddress();
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcore-lib-dash",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "description": "A pure and powerful JavaScript Dash library.",
   "author": "BitPay <dev@bitpay.com>",
   "main": "index.js",

--- a/test/govobject/govobject.js
+++ b/test/govobject/govobject.js
@@ -48,6 +48,10 @@ describe('GovObject', function(){
       govObject._verifyAddress('XuYDEzZzKxn&&knPDiVKe91sJasfajkshfjD1nQnnn5B6','livenet').should.equal(false);
       govObject._verifyAddress('knPDiVKe91sJasfajkshfjD1nQnnn5B6','testnet').should.equal(false);
       govObject._verifyAddress('XuYDEzZzKxn&&knPDiVKe91sJa/sfajkshfjD1nQnnn5B6','livenet').should.equal(false);
+      govObject._verifyAddress('XuYDEzZzKxnknPDiVKe91sJaD1nQnnn5B','livenet').should.equal(false);
+      govObject._verifyAddress(' XuYDEzZzKxnknPDiVKe91sJaD1nQnnn5B','livenet').should.equal(false);
+      govObject._verifyAddress('XuYDEzZzKxnknPDiVKe91sJaD1nQnnn5B ','livenet').should.equal(false);
+      govObject._verifyAddress('$XuYDEzZzKxnknPDiVKe91sJaD1nQnnn5B','livenet').should.equal(false);
     })
     it('should cast a stringified JSON Proposal into a Proposal Object', function(){
       var govObject = new GovObject;

--- a/test/govobject/govobject.js
+++ b/test/govobject/govobject.js
@@ -41,6 +41,14 @@ describe('GovObject', function(){
       expect(govObjRes).to.not.throw('Unhandled GovObject type');
       govObject.serialize().should.equal(expectedHex);
     })
+    it('should validate address', function(){
+      var govObject = new GovObject;
+      govObject._verifyAddress('yXGeNPQXYFXhLAN1ZKrAjxzzBnZ2JZNKnh','testnet').should.equal(true);
+      govObject._verifyAddress('XuYDEzZzKxnknPDiVKe91sJaD1nQnnn5B6','livenet').should.equal(true);
+      govObject._verifyAddress('XuYDEzZzKxn&&knPDiVKe91sJasfajkshfjD1nQnnn5B6','livenet').should.equal(false);
+      govObject._verifyAddress('knPDiVKe91sJasfajkshfjD1nQnnn5B6','testnet').should.equal(false);
+      govObject._verifyAddress('XuYDEzZzKxn&&knPDiVKe91sJa/sfajkshfjD1nQnnn5B6','livenet').should.equal(false);
+    })
     it('should cast a stringified JSON Proposal into a Proposal Object', function(){
       var govObject = new GovObject;
       var jsonProposal = {

--- a/test/govobject/govobject.js
+++ b/test/govobject/govobject.js
@@ -52,6 +52,8 @@ describe('GovObject', function(){
       govObject._verifyAddress(' XuYDEzZzKxnknPDiVKe91sJaD1nQnnn5B','livenet').should.equal(false);
       govObject._verifyAddress('XuYDEzZzKxnknPDiVKe91sJaD1nQnnn5B ','livenet').should.equal(false);
       govObject._verifyAddress('$XuYDEzZzKxnknPDiVKe91sJaD1nQnnn5B','livenet').should.equal(false);
+      govObject._verifyAddress('yXGeNPQXYFXhLAN1ZKrAjxzzBnZ2JZNKnh','livenet').should.equal(false);
+      govObject._verifyAddress('XuYDEzZzKxnknPDiVKe91sJaD1nQnnn5B6','testnet').should.equal(false);
     })
     it('should cast a stringified JSON Proposal into a Proposal Object', function(){
       var govObject = new GovObject;


### PR DESCRIPTION
This fix intend to solve an issue where one could pass a trailing space in the address and still have it validated. 
A prototype "Address" already exist and is able to handle that address verification. Therefore the use of this method has been put back. 