### PR TITLE
Feature/special transaction refactor

### DIFF
--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -27,6 +27,7 @@ var PrivateKey = require('../privatekey');
 var BN = require('../crypto/bn');
 var registeredTransactionTypes = require('./specialtransactions/constants').registeredTransactionTypes;
 var payloadParser = require('./specialtransactions/payload/payloadparser');
+var specialTransactionConstants = require('./specialtransactions/constants');
 
 /**
  * Represents a transaction, a set of inputs and outputs to change ownership of tokens
@@ -86,6 +87,8 @@ Transaction.FEE_PER_KB = 10000;
 // Safe upper bound for change address script size in bytes
 Transaction.CHANGE_OUTPUT_MAX_SIZE = 20 + 4 + 34 + 4;
 Transaction.MAXIMUM_EXTRA_SIZE = 4 + 9 + 9 + 4;
+
+Transaction.TYPES = specialTransactionConstants.registeredTransactionTypes;
 
 /* Constructors and Serialization */
 
@@ -1303,24 +1306,18 @@ Transaction.prototype.hasExtraPayload = function() {
 };
 
 /**
- * Sets DIP2 extra payload and calculates its size.
- * @param {Buffer} extraPayload
- * @returns {Transaction}
+ * @param {AbstractPayload} payload
+ * @return {Transaction}
  */
-Transaction.prototype.setExtraPayloadFromBuffer = function(extraPayload) {
-  $.checkArgument(BufferUtil.isBuffer(extraPayload), 'extraPayload should be a Buffer');
-  $.checkArgument(extraPayload.length > 0, 'extraPayload must be not empty');
-  this.extraPayloadSize = extraPayload.length;
-  this.extraPayload = extraPayload;
-  this.payload = payloadParser.parsePayloadBuffer(this.type, this.extraPayload);
-  return this;
-};
-
 Transaction.prototype.setExtraPayload = function(payload) {
   this.extraPayload = payload;
   return this;
 };
 
+/**
+ * Return extra payload size in bytes
+ * @return {Number}
+ */
 Transaction.prototype.getExtraPayloadSize = function getExtraPayloadSize() {
   return payloadParser.serializePayloadToBuffer(this.extraPayload).length;
 };

--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -1095,7 +1095,7 @@ Transaction.prototype.removeInput = function(txId, outputIndex) {
  * (matches a public key).
  *
  * @param {Array|String|PrivateKey} privateKey
- * @param {number} sigtype
+ * @param {number} [sigtype]
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.sign = function(privateKey, sigtype) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "A pure and powerful JavaScript Dash library.",
   "author": "BitPay <dev@bitpay.com>",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "A pure and powerful JavaScript Dash library.",
   "author": "BitPay <dev@bitpay.com>",
   "main": "index.js",


### PR DESCRIPTION
This PR contains few fixes for special transactions:
1. Remove `Transaction#setPayloadFromBuffer` method, as it's not needed anymore;
2. Make `Transaction#sign` `sigtype` parameter optional in jsdoc, to match actual implementation;
3. Added types constant to the `Transaction` class for easier access