### PR TITLE
fix bitcore global naming conflict

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ bitcore.versionGuard = function(version) {
     console.warn(message);
   }
 };
-bitcore.versionGuard(global._bitcore);
-global._bitcore = bitcore.version;
+bitcore.versionGuard(global._dashcore);
+global._dashcore = bitcore.version;
 
 // crypto
 bitcore.crypto = {};

--- a/test/index.js
+++ b/test/index.js
@@ -5,8 +5,8 @@ var sinon = require('sinon');
 var bitcore = require('../');
 
 describe('#versionGuard', function() {
-  it('global._bitcore should be defined', function() {
-    should.equal(global._bitcore, bitcore.version);
+  it('global._dashcore should be defined', function() {
+    should.equal(global._dashcore, bitcore.version);
   });
 
   it('throw a warning if version is already defined', function() {


### PR DESCRIPTION
This renames global versionGuard variable to _dashcore so that `@dashevo/dashcore-lib` and `bitcore-lib` can co-exist.

Fixes #57.