### PR TITLE
remove isUnsignedInteger check for creditFee because of error if 0

### DIFF
--- a/lib/transaction/payload/subtxcloseaccountpayload.js
+++ b/lib/transaction/payload/subtxcloseaccountpayload.js
@@ -120,7 +120,6 @@ SubTxCloseAccountPayload.prototype.validate = function() {
   Preconditions.checkArgument(isUnsignedInteger(this.version), 'Expect version to be an unsigned integer');
   Preconditions.checkArgument(isSha256HexString(this.regTxHash), 'Expect regTxHash to be a hex string representing sha256 hash');
   Preconditions.checkArgument(isSha256HexString(this.hashPrevSubTx), 'Expect hashPrevSubTx to be a hex string representing sha256 hash');
-  Preconditions.checkArgument(isUnsignedInteger(this.creditFee), 'Expect creditFee to be an unsigned integer');
   if (this.payloadSig && this.payloadSigSize !== 0) {
     Preconditions.checkArgumentType(this.payloadSigSize, 'number', 'payloadSigSize');
     Preconditions.checkArgument(isHexString(this.payloadSig), 'expect payloadSig to be a hex string but got ' + typeof this.payloadSig);


### PR DESCRIPTION
Removing redundant check if creditFee isUnsignedInteger, because creditFee is an optional field in the subtxcloseaccount payload and if it is not set then it will be set to 0 in the special tx payload. Which in turn will cause an error in the utils.isUnsignedInteger check. Removing it is safe because the field has already been checked if it's being a number