### PR TITLE
bugfix: use .writeVarintNum instead of .write

### DIFF
--- a/lib/transaction/payload/proregtxpayload.js
+++ b/lib/transaction/payload/proregtxpayload.js
@@ -219,7 +219,7 @@ ProRegTxPayload.prototype.toBuffer = function toBuffer(options) {
     payloadBufferWriter.writeVarintNum(Buffer.from(this.payloadSig, 'hex').length);
     payloadBufferWriter.write(Buffer.from(this.payloadSig, 'hex'));
   } else {
-    payloadBufferWriter.write(constants.EMPTY_SIGNATURE_SIZE);
+    payloadBufferWriter.writeVarintNum(constants.EMPTY_SIGNATURE_SIZE);
   }
 
   return payloadBufferWriter.toBuffer();


### PR DESCRIPTION
My insight-api test installation crashed at line 222:25 and really there should be .writeVarintNum instead of .write here. Hope this fix prevents this crash in the future.

```
[2018-12-23T04:25:10.399Z] error: uncaught exception: { AssertionError [ERR_ASSERTION]: false == true
    at BufferWriter.write (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/encoding/bufferwriter.js:29:3)
    at ProRegTxPayload.toBuffer (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/payload/proregtxpayload.js:222:25)
    at Object.serializePayloadToBuffer [as serializeToBuffer] (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/payload/payload.js:89:18)
    at Transaction.toBufferWriter (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:313:27)
    at Transaction.toBuffer (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:322:15)
    at Transaction._getHash (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:136:33)
    at Transaction.get (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:112:34)
    at Transaction.toObject (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:372:16)
    at /home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/block/block.js:144:26
    at Array.forEach (<anonymous>)
  generatedMessage: true,
  name: 'AssertionError [ERR_ASSERTION]',
  code: 'ERR_ASSERTION',
  actual: false,
  expected: true,
  operator: '==' }
[2018-12-23T04:25:10.401Z] error: AssertionError [ERR_ASSERTION]: false == true
    at BufferWriter.write (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/encoding/bufferwriter.js:29:3)
    at ProRegTxPayload.toBuffer (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/payload/proregtxpayload.js:222:25)
    at Object.serializePayloadToBuffer [as serializeToBuffer] (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/payload/payload.js:89:18)
    at Transaction.toBufferWriter (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:313:27)
    at Transaction.toBuffer (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:322:15)
    at Transaction._getHash (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:136:33)
    at Transaction.get (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:112:34)
    at Transaction.toObject (/home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:372:16)
    at /home/cofresi/.nvm/versions/node/v8.13.0/lib/node_modules/@dashevo/dashcore-node/node_modules/@dashevo/dashcore-lib/lib/block/block.js:144:26
    at Array.forEach (<anonymous>)
[2018-12-23T04:25:10.401Z] info: Beginning shutdown
[2018-12-23T04:25:10.402Z] info: Stopping @dashevo/insight-ui
[2018-12-23T04:25:10.402Z] info: Stopping @dashevo/insight-api
[2018-12-23T04:25:10.403Z] info: Stopping web
[2018-12-23T04:25:10.404Z] info: Stopping dashd
```