### PR TITLE
Clean up .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,6 @@
-*.swp
-.idea
-coverage
+# do not track dependencies
 node_modules
-browser/tests.js
-docs/api
 
-dist/mocha-test.js
-
-CONTRIBUTING.html
-LICENSE.html
-README.html
-examples.html
-npm-debug.log
-
-apiref
-bower_components
-report
-.DS_Store
-
-
-bitcore.js
-bitcore.min.js
-bitcore.js.sig
-bitcore.min.js.sig
-tests.js
-
-launch.json
-
+# ignore generated code coverage output
+coverage
 .nyc_output/


### PR DESCRIPTION
This is an attempt to clean up and remove most of the un-necessary cruft. This
current .gitignore is a mess, is not commented, and has a lot of leftover bad
practices from BitPay.

Specifically, it:

* Removes temporary editor files. Per [advice from the actual Git project
  itself](https://github.com/git/git-scm.com/blob/9787d513f0404f1f86c55c4c52714be73e5fde70/.gitignore#L3):

> If you find yourself ignoring temporary files generated by your text editor
> or operating system, you probably want to add a global ignore instead:
>   git config --global core.excludesfile ~/.gitignore_global

So, these should not be in per-project .gitignores, but rather a user's global
gitignore file.

* Removes references to non-existent files (which should never have been
  .gitignore'd in the first place)

* Leaves node_modules and coverage dirs for ignoral (Not sure if a real word?),
  and comments describing why those are there.