### PR TITLE
Fix/deprecated buffer usage

### DIFF
--- a/benchmark/serialization.js
+++ b/benchmark/serialization.js
@@ -31,7 +31,7 @@ async.series([
       buffers.push(br.toBuffer());
 
       // hashes
-      var data = bitcore.crypto.Hash.sha256sha256(new Buffer(32));
+      var data = bitcore.crypto.Hash.sha256sha256(Buffer.alloc(32));
       hashBuffers.push(data);
     }
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -67,7 +67,7 @@ var address = privateKey.toAddress();
 
 ## Generate an address from a SHA256 hash
 ```javascript
-var value = new Buffer('correct horse battery staple');
+var value = Buffer.from('correct horse battery staple');
 var hash = bitcore.crypto.Hash.sha256(value);
 var bn = bitcore.crypto.BN.fromBuffer(hash);
 

--- a/docs/script.md
+++ b/docs/script.md
@@ -83,7 +83,7 @@ var script = Script()
   .add('OP_IF')                       // add an opcode by name
   .prepend(114)                       // add OP_2SWAP by code
   .add(Opcode.OP_NOT)                 // add an opcode object
-  .add(new Buffer('bacacafe', 'hex')) // add a data buffer (will append the size of the push operation first)
+  .add(Buffer.from('bacacafe', 'hex')) // add a data buffer (will append the size of the push operation first)
 
 assert(script.toString() === 'OP_2SWAP OP_IF OP_NOT 4 0xbacacafe');
 ```
@@ -92,7 +92,7 @@ assert(script.toString() === 'OP_2SWAP OP_IF OP_NOT 4 0xbacacafe');
 `Script` has an easy interface to parse raw scripts from the network or dashd, and to extract useful information. An illustrative example (for more options check the API reference)
 
 ```javascript
-var raw_script = new Buffer('5221022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da2103e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e921021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc1853ae', 'hex');
+var raw_script = Buffer.from('5221022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da2103e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e921021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc1853ae', 'hex');
 var s = new Script(raw_script);
 console.log(s.toString());
 // 'OP_2 33 0x022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da 33 0x03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9 33 0x021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18 OP_3 OP_CHECKMULTISIG'

--- a/lib/address.js
+++ b/lib/address.js
@@ -149,7 +149,7 @@ Address._transformObject = function(data) {
   $.checkArgument(data.hash || data.hashBuffer, 'Must provide a `hash` or `hashBuffer` property');
   $.checkArgument(data.type, 'Must provide a `type` property');
   return {
-    hashBuffer: data.hash ? new Buffer(data.hash, 'hex') : data.hashBuffer,
+    hashBuffer: data.hash ? Buffer.from(data.hash, 'hex') : data.hashBuffer,
     network: Networks.get(data.network) || Networks.defaultNetwork,
     type: data.type
   };
@@ -394,7 +394,7 @@ Address.fromObject = function fromObject(obj) {
     JSUtil.isHexa(obj.hash),
     'Unexpected hash property, "' + obj.hash + '", expected to be hex.'
   );
-  var hashBuffer = new Buffer(obj.hash, 'hex');
+  var hashBuffer = Buffer.from(obj.hash, 'hex');
   return new Address(hashBuffer, obj.network, obj.type);
 };
 
@@ -462,7 +462,7 @@ Address.prototype.isPayToScriptHash = function() {
  * @returns {Buffer} Bitcoin address buffer
  */
 Address.prototype.toBuffer = function() {
-  var version = new Buffer([this.network[this.type]]);
+  var version = Buffer.from([this.network[this.type]]);
   var buf = Buffer.concat([version, this.hashBuffer]);
   return buf;
 };

--- a/lib/block/block.js
+++ b/lib/block/block.js
@@ -120,7 +120,7 @@ Block.fromBuffer = function fromBuffer(buf) {
  * @returns {Block} - A hex encoded string of the block
  */
 Block.fromString = function fromString(str) {
-  var buf = new Buffer(str, 'hex');
+  var buf = Buffer.from(str, 'hex');
   return Block.fromBuffer(buf);
 };
 
@@ -130,7 +130,7 @@ Block.fromString = function fromString(str) {
  */
 Block.fromRawBlock = function fromRawBlock(data) {
   if (!BufferUtil.isBuffer(data)) {
-    data = new Buffer(data, 'binary');
+    data = Buffer.from(data, 'binary');
   }
   var br = BufferReader(data);
   br.pos = Block.Values.START_OF_BLOCK;
@@ -278,7 +278,7 @@ Block.prototype.inspect = function inspect() {
 
 Block.Values = {
   START_OF_BLOCK: 8, // Start of block in raw block data
-  NULL_HASH: new Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
+  NULL_HASH: Buffer.from('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
 };
 
 module.exports = Block;

--- a/lib/block/blockheader.js
+++ b/lib/block/blockheader.js
@@ -73,10 +73,10 @@ BlockHeader._fromObject = function _fromObject(data) {
   var prevHash = data.prevHash;
   var merkleRoot = data.merkleRoot;
   if (_.isString(data.prevHash)) {
-    prevHash = BufferUtil.reverse(new Buffer(data.prevHash, 'hex'));
+    prevHash = BufferUtil.reverse(Buffer.from(data.prevHash, 'hex'));
   }
   if (_.isString(data.merkleRoot)) {
-    merkleRoot = BufferUtil.reverse(new Buffer(data.merkleRoot, 'hex'));
+    merkleRoot = BufferUtil.reverse(Buffer.from(data.merkleRoot, 'hex'));
   }
   var info = {
     hash: data.hash,
@@ -106,7 +106,7 @@ BlockHeader.fromObject = function fromObject(obj) {
  */
 BlockHeader.fromRawBlock = function fromRawBlock(data) {
   if (!BufferUtil.isBuffer(data)) {
-    data = new Buffer(data, 'binary');
+    data = Buffer.from(data, 'binary');
   }
   var br = BufferReader(data);
   br.pos = BlockHeader.Constants.START_OF_HEADER;
@@ -128,7 +128,7 @@ BlockHeader.fromBuffer = function fromBuffer(buf) {
  * @returns {BlockHeader} - An instance of block header
  */
 BlockHeader.fromString = function fromString(str) {
-  var buf = new Buffer(str, 'hex');
+  var buf = Buffer.from(str, 'hex');
   return BlockHeader.fromBuffer(buf);
 };
 

--- a/lib/block/merkleblock.js
+++ b/lib/block/merkleblock.js
@@ -104,7 +104,7 @@ MerkleBlock.prototype.toBufferWriter = function toBufferWriter(bw) {
   bw.writeUInt32LE(this.numTransactions);
   bw.writeVarintNum(this.hashes.length);
   for (var i = 0; i < this.hashes.length; i++) {
-    bw.write(new Buffer(this.hashes[i], 'hex'));
+    bw.write(Buffer.from(this.hashes[i], 'hex'));
   }
   bw.writeVarintNum(this.flags.length);
   for (i = 0; i < this.flags.length; i++) {
@@ -185,14 +185,14 @@ MerkleBlock.prototype._traverseMerkleTree = function traverseMerkleTree(depth, p
     if(depth === 0 && isParentOfMatch) {
       opts.txs.push(hash);
     }
-    return new Buffer(hash, 'hex');
+    return Buffer.from(hash, 'hex');
   } else {
     var left = this._traverseMerkleTree(depth-1, pos*2, opts);
     var right = left;
     if(pos*2+1 < this._calcTreeWidth(depth-1)) {
       right = this._traverseMerkleTree(depth-1, pos*2+1, opts);
     }
-    return Hash.sha256sha256(new Buffer.concat([left, right]));
+    return Hash.sha256sha256(Buffer.concat([left, right]));
   }
 };
 
@@ -232,7 +232,7 @@ MerkleBlock.prototype.hasTransaction = function hasTransaction(tx) {
   var hash = tx;
   if(tx instanceof Transaction) {
     // We need to reverse the id hash for the lookup
-    hash = BufferUtil.reverse(new Buffer(tx.id, 'hex')).toString('hex');
+    hash = BufferUtil.reverse(Buffer.from(tx.id, 'hex')).toString('hex');
   }
 
   var txs = [];

--- a/lib/crypto/bn.js
+++ b/lib/crypto/bn.js
@@ -8,7 +8,7 @@ var $ = require('../util/preconditions');
 var _ = require('lodash');
 
 var reversebuf = function(buf) {
-  var buf2 = new Buffer(buf.length);
+  var buf2 = Buffer.alloc(buf.length);
   for (var i = 0; i < buf.length; i++) {
     buf2[i] = buf[buf.length - 1 - i];
   }
@@ -45,7 +45,7 @@ BN.fromBuffer = function(buf, opts) {
 BN.fromSM = function(buf, opts) {
   var ret;
   if (buf.length === 0) {
-    return BN.fromBuffer(new Buffer([0]));
+    return BN.fromBuffer(Buffer.from([0]));
   }
 
   var endian = 'big';
@@ -76,7 +76,7 @@ BN.prototype.toBuffer = function(opts) {
   if (opts && opts.size) {
     hex = this.toString(16, 2);
     var natlen = hex.length / 2;
-    buf = new Buffer(hex, 'hex');
+    buf = Buffer.from(hex, 'hex');
 
     if (natlen === opts.size) {
       buf = buf;
@@ -87,7 +87,7 @@ BN.prototype.toBuffer = function(opts) {
     }
   } else {
     hex = this.toString(16, 2);
-    buf = new Buffer(hex, 'hex');
+    buf = Buffer.from(hex, 'hex');
   }
 
   if (typeof opts !== 'undefined' && opts.endian === 'little') {
@@ -102,19 +102,19 @@ BN.prototype.toSMBigEndian = function() {
   if (this.cmp(BN.Zero) === -1) {
     buf = this.neg().toBuffer();
     if (buf[0] & 0x80) {
-      buf = Buffer.concat([new Buffer([0x80]), buf]);
+      buf = Buffer.concat([Buffer.from([0x80]), buf]);
     } else {
       buf[0] = buf[0] | 0x80;
     }
   } else {
     buf = this.toBuffer();
     if (buf[0] & 0x80) {
-      buf = Buffer.concat([new Buffer([0x00]), buf]);
+      buf = Buffer.concat([Buffer.from([0x00]), buf]);
     }
   }
 
   if (buf.length === 1 & buf[0] === 0) {
-    buf = new Buffer([]);
+    buf = Buffer.from([]);
   }
   return buf;
 };
@@ -192,7 +192,7 @@ BN.trim = function(buf, natlen) {
 };
 
 BN.pad = function(buf, natlen, size) {
-  var rbuf = new Buffer(size);
+  var rbuf = Buffer.alloc(size);
   for (var i = 0; i < buf.length; i++) {
     rbuf[rbuf.length - 1 - i] = buf[buf.length - 1 - i];
   }

--- a/lib/crypto/ecdsa.js
+++ b/lib/crypto/ecdsa.js
@@ -84,17 +84,17 @@ ECDSA.prototype.deterministicK = function(badrs) {
   if (_.isUndefined(badrs)) {
     badrs = 0;
   }
-  var v = new Buffer(32);
+  var v = Buffer.alloc(32);
   v.fill(0x01);
-  var k = new Buffer(32);
+  var k = Buffer.alloc(32);
   k.fill(0x00);
   var x = this.privkey.bn.toBuffer({
     size: 32
   });
   var hashbuf = this.endian === 'little' ? BufferUtil.reverse(this.hashbuf) : this.hashbuf
-  k = Hash.sha256hmac(Buffer.concat([v, new Buffer([0x00]), x, hashbuf]), k);
+  k = Hash.sha256hmac(Buffer.concat([v, Buffer.from([0x00]), x, hashbuf]), k);
   v = Hash.sha256hmac(v, k);
-  k = Hash.sha256hmac(Buffer.concat([v, new Buffer([0x01]), x, hashbuf]), k);
+  k = Hash.sha256hmac(Buffer.concat([v, Buffer.from([0x01]), x, hashbuf]), k);
   v = Hash.sha256hmac(v, k);
   v = Hash.sha256hmac(v, k);
   var T = BN.fromBuffer(v);
@@ -102,7 +102,7 @@ ECDSA.prototype.deterministicK = function(badrs) {
 
   // also explained in 3.2, we must ensure T is in the proper range (0, N)
   for (var i = 0; i < badrs || !(T.lt(N) && T.gt(BN.Zero)); i++) {
-    k = Hash.sha256hmac(Buffer.concat([v, new Buffer([0x00])]), k);
+    k = Hash.sha256hmac(Buffer.concat([v, Buffer.from([0x00])]), k);
     v = Hash.sha256hmac(v, k);
     v = Hash.sha256hmac(v, k);
     T = BN.fromBuffer(v);
@@ -195,7 +195,7 @@ ECDSA.prototype.sigError = function() {
 ECDSA.toLowS = function(s) {
   //enforce low s
   //see BIP 62, "low S values in signatures"
-  if (s.gt(BN.fromBuffer(new Buffer('7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0', 'hex')))) {
+  if (s.gt(BN.fromBuffer(Buffer.from('7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0', 'hex')))) {
     s = Point.getN().sub(s);
   }
   return s;

--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -32,7 +32,7 @@ Hash.sha256sha256 = function(buf) {
 
 Hash.x11 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return new Buffer.from(x11hash.digest(buf, 1, 1));
+  return Buffer.from(x11hash.digest(buf, 1, 1));
 };
 
 Hash.ripemd160 = function(buf) {
@@ -64,20 +64,20 @@ Hash.hmac = function(hashf, data, key) {
   if (key.length > blocksize) {
     key = hashf(key);
   } else if (key < blocksize) {
-    var fill = new Buffer(blocksize);
+    var fill = Buffer.alloc(blocksize);
     fill.fill(0);
     key.copy(fill);
     key = fill;
   }
 
-  var o_key = new Buffer(blocksize);
+  var o_key = Buffer.alloc(blocksize);
   o_key.fill(0x5c);
 
-  var i_key = new Buffer(blocksize);
+  var i_key = Buffer.alloc(blocksize);
   i_key.fill(0x36);
 
-  var o_key_pad = new Buffer(blocksize);
-  var i_key_pad = new Buffer(blocksize);
+  var o_key_pad = Buffer.alloc(blocksize);
+  var i_key_pad = Buffer.alloc(blocksize);
   for (var i = 0; i < blocksize; i++) {
     o_key_pad[i] = o_key[i] ^ key[i];
     i_key_pad[i] = i_key[i] ^ key[i];

--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -3,7 +3,6 @@
 
 'use strict';
 
-var sha512 = require('sha512');
 var x11hash = require('@dashevo/x11-hash-js');
 var crypto = require('crypto');
 var BufferUtil = require('../util/buffer');

--- a/lib/crypto/hashsignature.js
+++ b/lib/crypto/hashsignature.js
@@ -39,7 +39,7 @@ var hashSignature = {
       sig: signature
     }).toPublicKey();
     var extractedPubKeyId = extractedPublicKey._getID();
-    var pubKeyId = new Buffer(publicKeyId, 'hex');
+    var pubKeyId = Buffer.from(publicKeyId, 'hex');
 
     return extractedPubKeyId.equals(pubKeyId);
   }

--- a/lib/crypto/point.js
+++ b/lib/crypto/point.js
@@ -143,9 +143,9 @@ Point.pointToCompressed = function pointToCompressed(point) {
   var prefix;
   var odd = ybuf[ybuf.length - 1] % 2;
   if (odd) {
-    prefix = new Buffer([0x03]);
+    prefix = Buffer.from([0x03]);
   } else {
-    prefix = new Buffer([0x02]);
+    prefix = Buffer.from([0x02]);
   }
   return BufferUtil.concat([prefix, xbuf]);
 };

--- a/lib/crypto/random.js
+++ b/lib/crypto/random.js
@@ -32,7 +32,7 @@ Random.getRandomBufferBrowser = function(size) {
 
   var bbuf = new Uint8Array(size);
   crypto.getRandomValues(bbuf);
-  var buf = new Buffer(bbuf);
+  var buf = Buffer.from(bbuf);
 
   return buf;
 };
@@ -40,7 +40,7 @@ Random.getRandomBufferBrowser = function(size) {
 /* insecure random bytes, but it never fails */
 Random.getPseudoRandomBuffer = function(size) {
   var b32 = 0x100000000;
-  var b = new Buffer(size);
+  var b = Buffer.alloc(size);
   var r;
 
   for (var i = 0; i <= size; i++) {

--- a/lib/crypto/signature.js
+++ b/lib/crypto/signature.js
@@ -82,7 +82,7 @@ Signature.fromTxFormat = function(buf) {
 };
 
 Signature.fromString = function(str) {
-  var buf = new Buffer(str, 'hex');
+  var buf = Buffer.from(str, 'hex');
   return Signature.fromDER(buf);
 };
 
@@ -157,7 +157,7 @@ Signature.prototype.toCompact = function(i, compressed) {
   if (compressed === false) {
     val = val - 4;
   }
-  var b1 = new Buffer([val]);
+  var b1 = Buffer.from([val]);
   var b2 = this.r.toBuffer({
     size: 32
   });
@@ -174,8 +174,8 @@ Signature.prototype.toBuffer = Signature.prototype.toDER = function() {
   var rneg = rnbuf[0] & 0x80 ? true : false;
   var sneg = snbuf[0] & 0x80 ? true : false;
 
-  var rbuf = rneg ? Buffer.concat([new Buffer([0x00]), rnbuf]) : rnbuf;
-  var sbuf = sneg ? Buffer.concat([new Buffer([0x00]), snbuf]) : snbuf;
+  var rbuf = rneg ? Buffer.concat([Buffer.from([0x00]), rnbuf]) : rnbuf;
+  var sbuf = sneg ? Buffer.concat([Buffer.from([0x00]), snbuf]) : snbuf;
 
   var rlength = rbuf.length;
   var slength = sbuf.length;
@@ -184,7 +184,7 @@ Signature.prototype.toBuffer = Signature.prototype.toDER = function() {
   var sheader = 0x02;
   var header = 0x30;
 
-  var der = Buffer.concat([new Buffer([header, length, rheader, rlength]), rbuf, new Buffer([sheader, slength]), sbuf]);
+  var der = Buffer.concat([Buffer.from([header, length, rheader, rlength]), rbuf, Buffer.from([sheader, slength]), sbuf]);
   return der;
 };
 
@@ -302,7 +302,7 @@ Signature.prototype.hasDefinedHashtype = function() {
 
 Signature.prototype.toTxFormat = function() {
   var derbuf = this.toDER();
-  var buf = new Buffer(1);
+  var buf = Buffer.alloc(1);
   buf.writeUInt8(this.nhashtype, 0);
   return Buffer.concat([derbuf, buf]);
 };

--- a/lib/encoding/base58.js
+++ b/lib/encoding/base58.js
@@ -48,7 +48,7 @@ Base58.decode = function(str) {
   if (typeof str !== 'string') {
     throw new Error('Input should be a string');
   }
-  return new Buffer(bs58.decode(str));
+  return Buffer.from(bs58.decode(str));
 };
 
 Base58.prototype.fromBuffer = function(buf) {

--- a/lib/encoding/base58.js
+++ b/lib/encoding/base58.js
@@ -5,7 +5,6 @@
 
 var _ = require('lodash');
 var bs58 = require('bs58');
-var buffer = require('buffer');
 
 var ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'.split('');
 
@@ -26,7 +25,7 @@ var Base58 = function Base58(obj) {
 };
 
 Base58.validCharacters = function validCharacters(chars) {
-  if (buffer.Buffer.isBuffer(chars)) {
+  if (Buffer.isBuffer(chars)) {
     chars = chars.toString();
   }
   return _.every(_.map(chars, function(char) { return _.includes(ALPHABET, char); }));
@@ -38,7 +37,7 @@ Base58.prototype.set = function(obj) {
 };
 
 Base58.encode = function(buf) {
-  if (!buffer.Buffer.isBuffer(buf)) {
+  if (!Buffer.isBuffer(buf)) {
     throw new Error('Input should be a buffer');
   }
   return bs58.encode(buf);

--- a/lib/encoding/base58check.js
+++ b/lib/encoding/base58check.js
@@ -5,7 +5,6 @@
 
 var _ = require('lodash');
 var Base58 = require('./base58');
-var buffer = require('buffer');
 var sha256sha256 = require('../crypto/hash').sha256sha256;
 
 var Base58Check = function Base58Check(obj) {
@@ -29,10 +28,10 @@ Base58Check.prototype.set = function(obj) {
 
 Base58Check.validChecksum = function validChecksum(data, checksum) {
   if (_.isString(data)) {
-    data = new buffer.Buffer(Base58.decode(data));
+    data = Buffer.from(Base58.decode(data));
   }
   if (_.isString(checksum)) {
-    checksum = new buffer.Buffer(Base58.decode(checksum));
+    checksum = Buffer.from(Base58.decode(checksum));
   }
   if (!checksum) {
     checksum = data.slice(-4);
@@ -45,7 +44,7 @@ Base58Check.decode = function(s) {
   if (typeof s !== 'string')
     throw new Error('Input must be a string');
 
-  var buf = new Buffer(Base58.decode(s));
+  var buf = Buffer.from(Base58.decode(s));
 
   if (buf.length < 4)
     throw new Error("Input string too short");
@@ -69,7 +68,7 @@ Base58Check.checksum = function(buffer) {
 Base58Check.encode = function(buf) {
   if (!Buffer.isBuffer(buf))
     throw new Error('Input must be a buffer');
-  var checkedBuf = new Buffer(buf.length + 4);
+  var checkedBuf = Buffer.alloc(buf.length + 4);
   var hash = Base58Check.checksum(buf);
   buf.copy(checkedBuf);
   hash.copy(checkedBuf, buf.length);

--- a/lib/encoding/bufferreader.js
+++ b/lib/encoding/bufferreader.js
@@ -21,7 +21,7 @@ var BufferReader = function BufferReader(buf) {
     });
   } else if (_.isString(buf)) {
     this.set({
-      buf: new Buffer(buf, 'hex'),
+      buf: Buffer.from(buf, 'hex'),
     });
   } else if (_.isObject(buf)) {
     var obj = buf;
@@ -181,7 +181,7 @@ BufferReader.prototype.readVarintBN = function() {
 };
 
 BufferReader.prototype.reverse = function() {
-  var buf = new Buffer(this.buf.length);
+  var buf = Buffer.alloc(this.buf.length);
   for (var i = 0; i < buf.length; i++) {
     buf[i] = this.buf[this.buf.length - 1 - i];
   }

--- a/lib/encoding/bufferwriter.js
+++ b/lib/encoding/bufferwriter.js
@@ -41,42 +41,42 @@ BufferWriter.prototype.writeReverse = function(buf) {
 };
 
 BufferWriter.prototype.writeUInt8 = function(n) {
-  var buf = new Buffer(1);
+  var buf = Buffer.alloc(1);
   buf.writeUInt8(n, 0);
   this.write(buf);
   return this;
 };
 
 BufferWriter.prototype.writeUInt16BE = function(n) {
-  var buf = new Buffer(2);
+  var buf = Buffer.alloc(2);
   buf.writeUInt16BE(n, 0);
   this.write(buf);
   return this;
 };
 
 BufferWriter.prototype.writeUInt16LE = function(n) {
-  var buf = new Buffer(2);
+  var buf = Buffer.alloc(2);
   buf.writeUInt16LE(n, 0);
   this.write(buf);
   return this;
 };
 
 BufferWriter.prototype.writeUInt32BE = function(n) {
-  var buf = new Buffer(4);
+  var buf = Buffer.alloc(4);
   buf.writeUInt32BE(n, 0);
   this.write(buf);
   return this;
 };
 
 BufferWriter.prototype.writeInt32LE = function(n) {
-  var buf = new Buffer(4);
+  var buf = Buffer.alloc(4);
   buf.writeInt32LE(n, 0);
   this.write(buf);
   return this;
 };
 
 BufferWriter.prototype.writeUInt32LE = function(n) {
-  var buf = new Buffer(4);
+  var buf = Buffer.alloc(4);
   buf.writeUInt32LE(n, 0);
   this.write(buf);
   return this;
@@ -109,18 +109,18 @@ BufferWriter.prototype.writeVarintBN = function(bn) {
 BufferWriter.varintBufNum = function(n) {
   var buf = undefined;
   if (n < 253) {
-    buf = new Buffer(1);
+    buf = Buffer.alloc(1);
     buf.writeUInt8(n, 0);
   } else if (n < 0x10000) {
-    buf = new Buffer(1 + 2);
+    buf = Buffer.alloc(1 + 2);
     buf.writeUInt8(253, 0);
     buf.writeUInt16LE(n, 1);
   } else if (n < 0x100000000) {
-    buf = new Buffer(1 + 4);
+    buf = Buffer.alloc(1 + 4);
     buf.writeUInt8(254, 0);
     buf.writeUInt32LE(n, 1);
   } else {
-    buf = new Buffer(1 + 8);
+    buf = Buffer.alloc(1 + 8);
     buf.writeUInt8(255, 0);
     buf.writeInt32LE(n & -1, 1);
     buf.writeUInt32LE(Math.floor(n / 0x100000000), 5);
@@ -132,14 +132,14 @@ BufferWriter.varintBufBN = function(bn) {
   var buf = undefined;
   var n = bn.toNumber();
   if (n < 253) {
-    buf = new Buffer(1);
+    buf = Buffer.alloc(1);
     buf.writeUInt8(n, 0);
   } else if (n < 0x10000) {
-    buf = new Buffer(1 + 2);
+    buf = Buffer.alloc(1 + 2);
     buf.writeUInt8(253, 0);
     buf.writeUInt16LE(n, 1);
   } else if (n < 0x100000000) {
-    buf = new Buffer(1 + 4);
+    buf = Buffer.alloc(1 + 4);
     buf.writeUInt8(254, 0);
     buf.writeUInt32LE(n, 1);
   } else {

--- a/lib/encoding/varint.js
+++ b/lib/encoding/varint.js
@@ -31,7 +31,7 @@ Varint.prototype.set = function(obj) {
 
 Varint.prototype.fromString = function(str) {
   this.set({
-    buf: new Buffer(str, 'hex')
+    buf: Buffer.from(str, 'hex')
   });
   return this;
 };

--- a/lib/govobject/govobject.js
+++ b/lib/govobject/govobject.js
@@ -5,8 +5,6 @@
 
 var _ = require('lodash');
 var $ = require('../util/preconditions');
-var buffer = require('buffer');
-var compare = Buffer.compare || require('buffer-compare');
 
 var errors = require('../errors');
 var BufferUtil = require('../util/buffer');
@@ -113,7 +111,7 @@ GovObject.prototype.fromObject = function fromObject(arg) {
  * @param string
  */
 GovObject.prototype.fromString = function(string) {
-    return this.fromBuffer(new buffer.Buffer(string, 'hex'));
+    return this.fromBuffer(Buffer.from(string, 'hex'));
 };
 
 /**
@@ -152,7 +150,7 @@ GovObject.prototype.toBuffer = function() {
 };
 
 GovObject.prototype.toBufferWriter = function(writer) {
-    writer.write(new Buffer(this.dataHex()));
+    writer.write(Buffer.from(this.dataHex()));
     return writer;
 };
 

--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -3,9 +3,7 @@
 
 'use strict';
 
-
 var assert = require('assert');
-var buffer = require('buffer');
 var _ = require('lodash');
 var $ = require('./util/preconditions');
 
@@ -242,12 +240,12 @@ HDPrivateKey.prototype._deriveWithNumber = function(index, hardened, nonComplian
     // The private key serialization in this case will not be exactly 32 bytes and can be
     // any value less, and the value is not zero-padded.
     var nonZeroPadded = this.privateKey.bn.toBuffer();
-    data = BufferUtil.concat([new buffer.Buffer([0]), nonZeroPadded, indexBuffer]);
+    data = BufferUtil.concat([Buffer.from([0]), nonZeroPadded, indexBuffer]);
   } else if (hardened) {
     // This will use a 32 byte zero padded serialization of the private key
     var privateKeyBuffer = this.privateKey.bn.toBuffer({size: 32});
     assert(privateKeyBuffer.length === 32, 'length of private key buffer is expected to be 32 bytes');
-    data = BufferUtil.concat([new buffer.Buffer([0]), privateKeyBuffer, indexBuffer]);
+    data = BufferUtil.concat([Buffer.from([0]), privateKeyBuffer, indexBuffer]);
   } else {
     data = BufferUtil.concat([this.publicKey.toBuffer(), indexBuffer]);
   }
@@ -420,7 +418,7 @@ HDPrivateKey.fromSeed = function(hexa, network) {
   if (hexa.length > MAXIMUM_ENTROPY_BITS * BITS_TO_BYTES) {
     throw new hdErrors.InvalidEntropyArgument.TooMuchEntropy(hexa);
   }
-  var hash = Hash.sha512hmac(hexa, new buffer.Buffer('Bitcoin seed'));
+  var hash = Hash.sha512hmac(hexa, Buffer.from('Bitcoin seed'));
 
   return new HDPrivateKey({
     network: Network.get(network) || Network.defaultNetwork,
@@ -446,13 +444,13 @@ HDPrivateKey.prototype._calcHDPublicKey = function() {
  * internal structure
  *
  * @param {Object} arg
- * @param {buffer.Buffer} arg.version
- * @param {buffer.Buffer} arg.depth
- * @param {buffer.Buffer} arg.parentFingerPrint
- * @param {buffer.Buffer} arg.childIndex
- * @param {buffer.Buffer} arg.chainCode
- * @param {buffer.Buffer} arg.privateKey
- * @param {buffer.Buffer} arg.checksum
+ * @param {Buffer} arg.version
+ * @param {Buffer} arg.depth
+ * @param {Buffer} arg.parentFingerPrint
+ * @param {Buffer} arg.childIndex
+ * @param {Buffer} arg.chainCode
+ * @param {Buffer} arg.privateKey
+ * @param {Buffer} arg.checksum
  * @param {string=} arg.xprivkey - if set, don't recalculate the base58
  *      representation
  * @return {HDPrivateKey} this
@@ -471,7 +469,7 @@ HDPrivateKey.prototype._buildFromBuffers = function(arg) {
     arg.version, arg.depth, arg.parentFingerPrint, arg.childIndex, arg.chainCode,
     BufferUtil.emptyBuffer(1), arg.privateKey
   ];
-  var concat = buffer.Buffer.concat(sequence);
+  var concat = Buffer.concat(sequence);
   if (!arg.checksum || !arg.checksum.length) {
     arg.checksum = Base58Check.checksum(concat);
   } else {
@@ -482,8 +480,8 @@ HDPrivateKey.prototype._buildFromBuffers = function(arg) {
 
   var network = Network.get(BufferUtil.integerFromBuffer(arg.version));
   var xprivkey;
-  xprivkey = Base58Check.encode(buffer.Buffer.concat(sequence));
-  arg.xprivkey = new Buffer(xprivkey);
+  xprivkey = Base58Check.encode(Buffer.concat(sequence));
+  arg.xprivkey = Buffer.from(xprivkey);
 
   var privateKey = new PrivateKey(BN.fromBuffer(arg.privateKey), network);
   var publicKey = privateKey.toPublicKey();

--- a/lib/hdpublickey.js
+++ b/lib/hdpublickey.js
@@ -351,7 +351,7 @@ HDPublicKey.prototype._buildFromBuffers = function(arg) {
 
   var xpubkey;
   xpubkey = Base58Check.encode(BufferUtil.concat(sequence));
-  arg.xpubkey = new Buffer(xpubkey);
+  arg.xpubkey = Buffer.from(xpubkey);
 
   var publicKey = new PublicKey(arg.publicKey, {network: network});
   var size = HDPublicKey.ParentFingerPrintSize;

--- a/lib/message.js
+++ b/lib/message.js
@@ -31,11 +31,11 @@ var Message = function Message(message) {
   return this;
 };
 
-Message.MAGIC_BYTES = new Buffer('DarkCoin Signed Message:\n');
+Message.MAGIC_BYTES = Buffer.from('DarkCoin Signed Message:\n');
 
 Message.prototype.magicHash = function magicHash() {
   var prefix1 = BufferWriter.varintBufNum(Message.MAGIC_BYTES.length);
-  var messageBuffer = new Buffer(this.message);
+  var messageBuffer = Buffer.from(this.message);
   var prefix2 = BufferWriter.varintBufNum(messageBuffer.length);
   var buf = Buffer.concat([prefix1, Message.MAGIC_BYTES, prefix2, messageBuffer]);
   var hash = sha256sha256(buf);
@@ -92,7 +92,7 @@ Message.prototype.verify = function verify(bitcoinAddress, signatureString) {
   if (_.isString(bitcoinAddress)) {
     bitcoinAddress = Address.fromString(bitcoinAddress);
   }
-  var signature = Signature.fromCompact(new Buffer(signatureString, 'base64'));
+  var signature = Signature.fromCompact(Buffer.from(signatureString, 'base64'));
 
   // recover the public key
   var ecdsa = new ECDSA();

--- a/lib/mnemonic/mnemonic.js
+++ b/lib/mnemonic/mnemonic.js
@@ -128,7 +128,7 @@ Mnemonic.isValid = function(mnemonic, wordlist) {
   var cs = bin.length / 33;
   var hash_bits = bin.slice(-cs);
   var nonhash_bits = bin.slice(0, bin.length - cs);
-  var buf = new Buffer(nonhash_bits.length / 8);
+  var buf = Buffer.alloc(nonhash_bits.length / 8);
   for (i = 0; i < nonhash_bits.length / 8; i++) {
     buf.writeUInt8(parseInt(bin.slice(i * 8, (i + 1) * 8), 2), i);
   }

--- a/lib/mnemonic/pbkdf2.js
+++ b/lib/mnemonic/pbkdf2.js
@@ -28,18 +28,18 @@ function pbkdf2(key, salt, iterations, dkLen) {
   }
 
   if (typeof key === 'string') {
-    key = new Buffer(key);
+    key = Buffer.from(key);
   }
 
   if (typeof salt === 'string') {
-    salt = new Buffer(salt);
+    salt = Buffer.from(salt);
   }
 
-  var DK = new Buffer(dkLen);
+  var DK = Buffer.alloc(dkLen);
 
-  var U = new Buffer(hLen);
-  var T = new Buffer(hLen);
-  var block1 = new Buffer(salt.length + 4);
+  var U = Buffer.alloc(hLen);
+  var T = Buffer.alloc(hLen);
+  var block1 = Buffer.alloc(salt.length + 4);
 
   var l = Math.ceil(dkLen / hLen);
   var r = dkLen - (l - 1) * hLen;

--- a/lib/opcode.js
+++ b/lib/opcode.js
@@ -54,7 +54,7 @@ Opcode.prototype.toHex = function() {
 };
 
 Opcode.prototype.toBuffer = function() {
-  return new Buffer(this.toHex(), 'hex');
+  return Buffer.from(this.toHex(), 'hex');
 };
 
 Opcode.prototype.toNumber = function() {

--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -106,7 +106,7 @@ PrivateKey.prototype._classifyArguments = function(data, network) {
     info.network = Networks.get(data);
   } else if (typeof(data) === 'string'){
     if (JSUtil.isHexa(data)) {
-      info.bn = new BN(new Buffer(data, 'hex'));
+      info.bn = new BN(Buffer.from(data, 'hex'));
     } else {
       info = PrivateKey._transformWIF(data, network);
     }
@@ -313,11 +313,11 @@ PrivateKey.prototype.toWIF = function() {
 
   var buf;
   if (compressed) {
-    buf = Buffer.concat([new Buffer([network.privatekey]),
+    buf = Buffer.concat([Buffer.from([network.privatekey]),
                          this.bn.toBuffer({size: 32}),
-                         new Buffer([0x01])]);
+                         Buffer.from([0x01])]);
   } else {
-    buf = Buffer.concat([new Buffer([network.privatekey]),
+    buf = Buffer.concat([Buffer.from([network.privatekey]),
                          this.bn.toBuffer({size: 32})]);
   }
 

--- a/lib/publickey.js
+++ b/lib/publickey.js
@@ -81,7 +81,7 @@ PublicKey.prototype._classifyArgs = function(data, extra) {
   } else if (data.x && data.y) {
     info = PublicKey._transformObject(data);
   } else if (typeof(data) === 'string') {
-    info = PublicKey._transformDER(new Buffer(data, 'hex'));
+    info = PublicKey._transformDER(Buffer.from(data, 'hex'));
   } else if (PublicKey._isBuffer(data)) {
     info = PublicKey._transformDER(data);
   } else if (PublicKey._isPrivateKey(data)) {
@@ -263,7 +263,7 @@ PublicKey.fromPoint = function(point, compressed) {
  * @returns {PublicKey} A new valid instance of PublicKey
  */
 PublicKey.fromString = function(str, encoding) {
-  var buf = new Buffer(str, encoding || 'hex');
+  var buf = Buffer.from(str, encoding || 'hex');
   var info = PublicKey._transformDER(buf);
   return new PublicKey(info.point, {
     compressed: info.compressed
@@ -340,14 +340,14 @@ PublicKey.prototype.toBuffer = PublicKey.prototype.toDER = function() {
 
   var prefix;
   if (!this.compressed) {
-    prefix = new Buffer([0x04]);
+    prefix = Buffer.from([0x04]);
     return Buffer.concat([prefix, xbuf, ybuf]);
   } else {
     var odd = ybuf[ybuf.length - 1] % 2;
     if (odd) {
-      prefix = new Buffer([0x03]);
+      prefix = Buffer.from([0x03]);
     } else {
-      prefix = new Buffer([0x02]);
+      prefix = Buffer.from([0x02]);
     }
     return Buffer.concat([prefix, xbuf]);
   }

--- a/lib/script/interpreter.js
+++ b/lib/script/interpreter.js
@@ -182,8 +182,8 @@ Interpreter.prototype.set = function(obj) {
   this.flags = typeof obj.flags !== 'undefined' ? obj.flags : this.flags;
 };
 
-Interpreter.true = new Buffer([1]);
-Interpreter.false = new Buffer([]);
+Interpreter.true = Buffer.from([1]);
+Interpreter.false = Buffer.from([]);
 
 Interpreter.MAX_SCRIPT_ELEMENT_SIZE = 520;
 
@@ -367,7 +367,7 @@ Interpreter.prototype.checkLockTime = function(nLockTime) {
   return true;
 }
 
-/** 
+/**
  * Based on the inner loop of bitcoind's EvalScript function
  * bitcoind commit: b5d1b1092998bc95313856d535c632ea5a8f9104
  */

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -14,7 +14,6 @@ var Networks = require('../networks');
 var $ = require('../util/preconditions');
 var _ = require('lodash');
 var errors = require('../errors');
-var buffer = require('buffer');
 var BufferUtil = require('../util/buffer');
 var JSUtil = require('../util/js');
 
@@ -146,7 +145,7 @@ Script.fromASM = function(str) {
     var opcodenum = opcode.toNumber();
 
     if (_.isUndefined(opcodenum)) {
-      var buf = new Buffer(tokens[i], 'hex');
+      var buf = Buffer.from(tokens[i], 'hex');
       script.chunks.push({
         buf: buf,
         len: buf.length,
@@ -157,7 +156,7 @@ Script.fromASM = function(str) {
       opcodenum === Opcode.OP_PUSHDATA2 ||
       opcodenum === Opcode.OP_PUSHDATA4) {
       script.chunks.push({
-        buf: new Buffer(tokens[i + 2], 'hex'),
+        buf: Buffer.from(tokens[i + 2], 'hex'),
         len: parseInt(tokens[i + 1]),
         opcodenum: opcodenum
       });
@@ -173,12 +172,12 @@ Script.fromASM = function(str) {
 };
 
 Script.fromHex = function(str) {
-  return new Script(new buffer.Buffer(str, 'hex'));
+  return new Script(Buffer.from(str, 'hex'));
 };
 
 Script.fromString = function(str) {
   if (JSUtil.isHexa(str) || str.length === 0) {
-    return new Script(new buffer.Buffer(str, 'hex'));
+    return new Script(Buffer.from(str, 'hex'));
   }
   var script = new Script();
   script.chunks = [];
@@ -194,7 +193,7 @@ Script.fromString = function(str) {
       opcodenum = parseInt(token);
       if (opcodenum > 0 && opcodenum < Opcode.OP_PUSHDATA1) {
         script.chunks.push({
-          buf: new Buffer(tokens[i + 1].slice(2), 'hex'),
+          buf: Buffer.from(tokens[i + 1].slice(2), 'hex'),
           len: opcodenum,
           opcodenum: opcodenum
         });
@@ -209,7 +208,7 @@ Script.fromString = function(str) {
         throw new Error('Pushdata data must start with 0x');
       }
       script.chunks.push({
-        buf: new Buffer(tokens[i + 2].slice(2), 'hex'),
+        buf: Buffer.from(tokens[i + 2].slice(2), 'hex'),
         len: parseInt(tokens[i + 1]),
         opcodenum: opcodenum
       });
@@ -467,13 +466,13 @@ Script.prototype.isDataOut = function() {
 Script.prototype.getData = function() {
   if (this.isDataOut() || this.isScriptHashOut()) {
     if (_.isUndefined(this.chunks[1])) {
-      return new Buffer(0);
+      return Buffer.alloc(0);
     } else {
-      return new Buffer(this.chunks[1].buf);
+      return Buffer.from(this.chunks[1].buf);
     }
   }
   if (this.isPublicKeyHashOut()) {
-    return new Buffer(this.chunks[2].buf);
+    return Buffer.from(this.chunks[2].buf);
   }
   throw new Error('Unrecognized script type to get data from');
 };
@@ -818,7 +817,7 @@ Script.buildPublicKeyOut = function(pubkey) {
 Script.buildDataOut = function(data, encoding) {
   $.checkArgument(_.isUndefined(data) || _.isString(data) || BufferUtil.isBuffer(data));
   if (_.isString(data)) {
-    data = new Buffer(data, encoding);
+    data = Buffer.from(data, encoding);
   }
   var s = new Script();
   s.add(Opcode.OP_RETURN);

--- a/lib/transaction/input/input.js
+++ b/lib/transaction/input/input.js
@@ -7,7 +7,6 @@ var _ = require('lodash');
 var $ = require('../../util/preconditions');
 var errors = require('../../errors');
 var BufferWriter = require('../../encoding/bufferwriter');
-var buffer = require('buffer');
 var BufferUtil = require('../../util/buffer');
 var JSUtil = require('../../util/js');
 var Script = require('../../script');
@@ -57,7 +56,7 @@ Input.fromObject = function(obj) {
 Input.prototype._fromObject = function(params) {
   var prevTxId;
   if (_.isString(params.prevTxId) && JSUtil.isHexa(params.prevTxId)) {
-    prevTxId = new buffer.Buffer(params.prevTxId, 'hex');
+    prevTxId = Buffer.from(params.prevTxId, 'hex');
   } else {
     prevTxId = params.prevTxId;
   }
@@ -123,7 +122,7 @@ Input.prototype.setScript = function(script) {
     this._scriptBuffer = script.toBuffer();
   } else if (JSUtil.isHexa(script)) {
     // hex string script
-    this._scriptBuffer = new buffer.Buffer(script, 'hex');
+    this._scriptBuffer = Buffer.from(script, 'hex');
   } else if (_.isString(script)) {
     // human readable string script
     this._script = new Script(script);
@@ -131,7 +130,7 @@ Input.prototype.setScript = function(script) {
     this._scriptBuffer = this._script.toBuffer();
   } else if (BufferUtil.isBuffer(script)) {
     // buffer script
-    this._scriptBuffer = new buffer.Buffer(script);
+    this._scriptBuffer = Buffer.from(script);
   } else {
     throw new TypeError('Invalid argument type: script');
   }

--- a/lib/transaction/output.js
+++ b/lib/transaction/output.js
@@ -5,7 +5,6 @@
 
 var _ = require('lodash');
 var BN = require('../crypto/bn');
-var buffer = require('buffer');
 var bufferUtil = require('../util/buffer');
 var JSUtil = require('../util/js');
 var BufferWriter = require('../encoding/bufferwriter');
@@ -26,7 +25,7 @@ function Output(args) {
     } else {
       var script;
       if (_.isString(args.script) && JSUtil.isHexa(args.script)) {
-        script = new buffer.Buffer(args.script, 'hex');
+        script = Buffer.from(args.script, 'hex');
       } else {
         script = args.script;
       }
@@ -152,7 +151,7 @@ Output.fromBufferReader = function(br) {
   if (size !== 0) {
     obj.script = br.read(size);
   } else {
-    obj.script = new buffer.Buffer([]);
+    obj.script = Buffer.from([]);
   }
   return new Output(obj);
 };

--- a/lib/transaction/sighash.js
+++ b/lib/transaction/sighash.js
@@ -3,8 +3,6 @@
 
 'use strict';
 
-var buffer = require('buffer');
-
 var Signature = require('../crypto/signature');
 var Script = require('../script');
 var Output = require('./output');
@@ -66,14 +64,14 @@ var sighash = function sighash(transaction, sighashType, inputNumber, subscript)
     // The SIGHASH_SINGLE bug.
     // https://bitcointalk.org/index.php?topic=260595.0
     if (inputNumber >= txcopy.outputs.length) {
-      return new Buffer(SIGHASH_SINGLE_BUG, 'hex');
+      return Buffer.from(SIGHASH_SINGLE_BUG, 'hex');
     }
 
     txcopy.outputs.length = inputNumber + 1;
 
     for (i = 0; i < inputNumber; i++) {
       txcopy.outputs[i] = new Output({
-        satoshis: BN.fromBuffer(new buffer.Buffer(BITS_64_ON, 'hex')),
+        satoshis: BN.fromBuffer(Buffer.from(BITS_64_ON, 'hex')),
         script: Script.empty()
       });
     }

--- a/lib/transaction/signature.js
+++ b/lib/transaction/signature.js
@@ -37,7 +37,7 @@ inherits(TransactionSignature, Signature);
 TransactionSignature.prototype._fromObject = function(arg) {
   this._checkObjectArgs(arg);
   this.publicKey = new PublicKey(arg.publicKey);
-  this.prevTxId = BufferUtil.isBuffer(arg.prevTxId) ? arg.prevTxId : new Buffer(arg.prevTxId, 'hex');
+  this.prevTxId = BufferUtil.isBuffer(arg.prevTxId) ? arg.prevTxId : Buffer.from(arg.prevTxId, 'hex');
   this.outputIndex = arg.outputIndex;
   this.inputIndex = arg.inputIndex;
   this.signature = (arg.signature instanceof Signature) ? arg.signature :

--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -5,7 +5,6 @@
 
 var _ = require('lodash');
 var $ = require('../util/preconditions');
-var buffer = require('buffer');
 var compare = Buffer.compare || require('buffer-compare');
 
 var errors = require('../errors');
@@ -532,7 +531,7 @@ Transaction.prototype.getLockTime = function() {
 };
 
 Transaction.prototype.fromString = function(string) {
-  this.fromBuffer(new buffer.Buffer(string, 'hex'));
+  this.fromBuffer(Buffer.from(string, 'hex'));
 };
 
 Transaction.prototype._newTransaction = function() {

--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -5,7 +5,6 @@
 
 var _ = require('lodash');
 var $ = require('../util/preconditions');
-var compare = Buffer.compare || require('buffer-compare');
 
 var errors = require('../errors');
 var BufferUtil = require('../util/buffer');
@@ -1007,7 +1006,7 @@ Transaction.prototype.sort = function() {
   this.sortInputs(function(inputs) {
     var copy = Array.prototype.concat.apply([], inputs);
     copy.sort(function(first, second) {
-      return compare(first.prevTxId, second.prevTxId)
+      return Buffer.compare(first.prevTxId, second.prevTxId)
         || first.outputIndex - second.outputIndex;
     });
     return copy;
@@ -1016,7 +1015,7 @@ Transaction.prototype.sort = function() {
     var copy = Array.prototype.concat.apply([], outputs);
     copy.sort(function(first, second) {
       return first.satoshis - second.satoshis
-        || compare(first.script.toBuffer(), second.script.toBuffer());
+        || Buffer.compare(first.script.toBuffer(), second.script.toBuffer());
     });
     return copy;
   });

--- a/lib/util/buffer.js
+++ b/lib/util/buffer.js
@@ -3,7 +3,6 @@
 
 'use strict';
 
-var buffer = require('buffer');
 var assert = require('assert');
 
 var js = require('./js');
@@ -47,7 +46,7 @@ module.exports = {
    * @return {Buffer}
    */
   copy: function(original) {
-    var buffer = new Buffer(original.length);
+    var buffer = Buffer.alloc(original.length);
     original.copy(buffer);
     return buffer;
   },
@@ -60,7 +59,7 @@ module.exports = {
    * @return {boolean}
    */
   isBuffer: function isBuffer(arg) {
-    return buffer.Buffer.isBuffer(arg) || arg instanceof Uint8Array;
+    return Buffer.isBuffer(arg) || arg instanceof Uint8Array;
   },
 
   /**
@@ -71,7 +70,7 @@ module.exports = {
    */
   emptyBuffer: function emptyBuffer(bytes) {
     $.checkArgumentType(bytes, 'number', 'bytes');
-    var result = new buffer.Buffer(bytes);
+    var result = Buffer.alloc(bytes);
     for (var i = 0; i < bytes; i++) {
       result.write('\0', i);
     }
@@ -81,9 +80,9 @@ module.exports = {
   /**
    * Concatenates a buffer
    *
-   * Shortcut for <tt>buffer.Buffer.concat</tt>
+   * Shortcut for <tt>Buffer.concat</tt>
    */
-  concat: buffer.Buffer.concat,
+  concat: Buffer.concat,
 
   equals: equals,
   equal: equals,
@@ -96,7 +95,7 @@ module.exports = {
    */
   integerAsSingleByteBuffer: function integerAsSingleByteBuffer(integer) {
     $.checkArgumentType(integer, 'number', 'integer');
-    return new buffer.Buffer([integer & 0xff]);
+    return Buffer.from([integer & 0xff]);
   },
 
   /**
@@ -112,7 +111,7 @@ module.exports = {
     bytes.push((integer >> 16) & 0xff);
     bytes.push((integer >> 8) & 0xff);
     bytes.push(integer & 0xff);
-    return new Buffer(bytes);
+    return Buffer.from(bytes);
   },
 
   /**
@@ -155,7 +154,7 @@ module.exports = {
    * @return {Buffer}
    */
   reverse: function reverse(param) {
-    var ret = new buffer.Buffer(param.length);
+    var ret = Buffer.alloc(param.length);
     for (var i = 0; i < param.length; i++) {
       ret[i] = param[param.length - i - 1];
     }
@@ -172,9 +171,9 @@ module.exports = {
    */
   hexToBuffer: function hexToBuffer(string) {
     assert(js.isHexa(string));
-    return new buffer.Buffer(string, 'hex');
+    return Buffer.from(string, 'hex');
   }
 };
 
-module.exports.NULL_HASH = module.exports.fill(new Buffer(32), 0);
-module.exports.EMPTY_BUFFER = new Buffer(0);
+module.exports.NULL_HASH = module.exports.fill(Buffer.alloc(32), 0);
+module.exports.EMPTY_BUFFER = Buffer.alloc(0);

--- a/lib/util/buffer.js
+++ b/lib/util/buffer.js
@@ -164,7 +164,7 @@ module.exports = {
   /**
    * Transforms an hex encoded string into a Buffer with binary values
    *
-   * Shorthand for <tt>Buffer(string, 'hex')</tt>
+   * Shorthand for <tt>Buffer.from(string, 'hex')</tt>
    *
    * @param {string} string
    * @return {Buffer}

--- a/lib/util/preconditions.js
+++ b/lib/util/preconditions.js
@@ -21,8 +21,7 @@ module.exports = {
     argumentName = argumentName || '(unknown name)';
     if (_.isString(type)) {
       if (type === 'Buffer') {
-        var buffer = require('buffer'); // './buffer' fails on cordova & RN
-        if (!buffer.Buffer.isBuffer(argument)) {
+        if (!Buffer.isBuffer(argument)) {
           throw new errors.InvalidArgumentType(argument, type, argumentName);
         }
       } else if (typeof argument !== type) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.16.1",
+  "version": "0.16.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -767,11 +767,6 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
       "dev": true
-    },
-    "buffer-compare": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.1.1.tgz",
-      "integrity": "sha1-W+e+hTr4kZjR9N3AkNHWakiu9ZY="
     },
     "buffer-equal": {
       "version": "0.0.1",
@@ -1590,7 +1585,7 @@
     },
     "engine.io-client": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "dev": true,
       "requires": {
@@ -2059,7 +2054,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -2181,7 +2176,7 @@
     },
     "expand-range": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
       "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
       "dev": true,
       "requires": {
@@ -2526,7 +2521,7 @@
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
@@ -2592,14 +2587,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2614,20 +2607,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2744,8 +2734,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2757,7 +2746,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2772,7 +2760,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2780,14 +2767,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2806,7 +2791,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2887,8 +2871,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2900,7 +2883,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3022,7 +3004,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3126,7 +3107,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -3497,7 +3478,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -4097,7 +4078,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -4216,7 +4197,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -4261,7 +4242,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4270,7 +4251,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -4407,7 +4388,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -5797,7 +5778,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -5842,7 +5823,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -5955,7 +5936,7 @@
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
@@ -5976,7 +5957,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -6045,7 +6026,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -6261,7 +6242,7 @@
     },
     "raw-loader": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
       "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
       "dev": true
     },
@@ -6504,7 +6485,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -6874,7 +6855,7 @@
     },
     "socket.io-parser": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "dev": true,
       "requires": {
@@ -7053,7 +7034,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
@@ -7149,7 +7130,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -7188,7 +7169,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
@@ -7200,7 +7181,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -7315,7 +7296,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
@@ -7615,7 +7596,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {
@@ -7759,7 +7740,7 @@
     },
     "webpack-dev-middleware": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz",
+      "resolved": "http://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz",
       "integrity": "sha512-tj5LLD9r4tDuRIDa5Mu9lnY2qBBehAITv6A9irqXhw/HQquZgTx3BCd57zYbU2gMDnncA49ufK2qVQSbaKJwOw==",
       "dev": true,
       "requires": {
@@ -7832,7 +7813,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -7857,7 +7838,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6591,11 +6591,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "sha512": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/sha512/-/sha512-0.0.1.tgz",
-      "integrity": "sha1-JuWQIu9qvHXHNE8KXvOTbK8lQtU="
-    },
     "shallow-copy": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "@dashevo/x11-hash-js": "^1.0.2",
     "bn.js": "=4.11.8",
     "bs58": "=4.0.1",
-    "buffer-compare": "=1.1.1",
     "elliptic": "=6.4.1",
     "inherits": "=2.0.1",
     "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "elliptic": "=6.4.1",
     "inherits": "=2.0.1",
     "lodash": "^4.17.11",
-    "sha512": "=0.0.1",
     "unorm": "^1.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "description": "A pure and powerful JavaScript Dash library.",
   "author": "Dash Core Group, Inc. <dev@dash.org>",
   "main": "index.js",

--- a/test/address.js
+++ b/test/address.js
@@ -20,8 +20,8 @@ var invalidbase58 = require('./data/bitcoind/base58_keys_invalid.json');
 
 describe('Address', function() {
 
-  var pubkeyhash = new Buffer('3c3fa3d4adcaf8f52d5b1843975e122548269937', 'hex');
-  var buf = Buffer.concat([new Buffer([0x4c]), pubkeyhash]);
+  var pubkeyhash = Buffer.from('3c3fa3d4adcaf8f52d5b1843975e122548269937', 'hex');
+  var buf = Buffer.concat([Buffer.from([0x4c]), pubkeyhash]);
   var str = 'XgBQcYbKff4q7cEs7AaxoPN2CAiBbFc2JT';
 
   it('can\'t build without data', function() {
@@ -279,25 +279,25 @@ describe('Address', function() {
 
     it('should error because of incorrect length buffer for transform buffer', function() {
       (function() {
-        return Address._transformBuffer(new Buffer(20));
+        return Address._transformBuffer(Buffer.alloc(20));
       }).should.throw('Address buffers must be exactly 21 bytes.');
     });
 
     it('should error because of incorrect type for pubkey transform', function() {
       (function() {
-        return Address._transformPublicKey(new Buffer(20));
+        return Address._transformPublicKey(Buffer.alloc(20));
       }).should.throw('Address must be an instance of PublicKey.');
     });
 
     it('should error because of incorrect type for script transform', function() {
       (function() {
-        return Address._transformScript(new Buffer(20));
+        return Address._transformScript(Buffer.alloc(20));
       }).should.throw('Invalid Argument: script must be a Script instance');
     });
 
     it('should error because of incorrect type for string transform', function() {
       (function() {
-        return Address._transformString(new Buffer(20));
+        return Address._transformString(Buffer.alloc(20));
       }).should.throw('data parameter supplied is not a string.');
     });
 

--- a/test/block/block.js
+++ b/test/block/block.js
@@ -24,8 +24,8 @@ var dataBlocks = require('../data/bitcoind/blocks');
 describe('Block', function() {
 
   var blockhex = data.blockhex;
-  var blockbuf = new Buffer(blockhex, 'hex');
-  var bh = BlockHeader.fromBuffer(new Buffer(data.blockheaderhex, 'hex'));
+  var blockbuf = Buffer.from(blockhex, 'hex');
+  var bh = BlockHeader.fromBuffer(Buffer.from(data.blockheaderhex, 'hex'));
   var txs = [];
   JSON.parse(dataJson).transactions.forEach(function(tx) {
     txs.push(new Transaction().fromObject(tx));
@@ -33,10 +33,10 @@ describe('Block', function() {
   var json = dataJson;
 
   var genesishex = '010000000000000000000000000000000000000000000000000000000000000000000000c762a6567f3cc092f0684bb62b7e00a84890b990f07cc71a6bb58d64b98e02e0022ddb52f0ff0f1ec23fb9010101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff6204ffff001d01044c5957697265642030392f4a616e2f3230313420546865204772616e64204578706572696d656e7420476f6573204c6976653a204f76657273746f636b2e636f6d204973204e6f7720416363657074696e6720426974636f696e73ffffffff0100f2052a010000004341040184710fa689ad5023690c80f3a49c8f13f8d45b8c857fbcbc8bc4a8e4d3eb4b10f4d4604fa08dce601aaf0f470216fe1b51850b4acf21b179c45070ac7b03a9ac00000000';
-  var genesisbuf = new Buffer(genesishex, 'hex');
+  var genesisbuf = Buffer.from(genesishex, 'hex');
   var genesisidhex = '00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6';
   var blockOneHex = '02000000b67a40f3cd5804437a108f105533739c37e6229bc1adcab385140b59fd0f0000a71c1aade44bf8425bec0deb611c20b16da3442818ef20489ca1e2512be43eef814cdb52f0ff0f1edbf701000101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0a510101062f503253482fffffffff0100743ba40b000000232103a69850243c993c0645a6e8b38c774174174cc766cd3ec2140afd24d831b84c41ac00000000';
-  var blockOneBuf = new Buffer(blockOneHex, 'hex');
+  var blockOneBuf = Buffer.from(blockOneHex, 'hex');
   var blockOneId = '000007d91d1254d60e2dd1ae580383070a4ddffa4c64c2eeb4a2f9ecc0414343';
 
   it('should make a new block', function() {
@@ -63,7 +63,7 @@ describe('Block', function() {
 
     it('should properly deserialize blocks', function() {
       dataBlocks.forEach(function(block) {
-        var b = Block.fromBuffer(new Buffer(block.data, 'hex'));
+        var b = Block.fromBuffer(Buffer.from(block.data, 'hex'));
         b.transactions.length.should.equal(block.transactions);
       });
     });
@@ -216,7 +216,7 @@ describe('Block', function() {
 
     it('should return the correct hash of the genesis block', function() {
       var block = Block.fromBuffer(genesisbuf);
-      var blockhash = new Buffer(Array.apply([], new Buffer(genesisidhex, 'hex')).reverse());
+      var blockhash = Buffer.from(Array.apply([], Buffer.from(genesisidhex, 'hex')).reverse());
       block._getHash().toString('hex').should.equal(blockhash.toString('hex'));
     });
   });

--- a/test/block/blockheader.js
+++ b/test/block/blockheader.js
@@ -21,8 +21,8 @@ var data = require('../data/blk19976-testnet');
 describe('BlockHeader', function() {
 
   var version = data.version;
-  var prevblockidbuf = new Buffer(data.prevblockidhex, 'hex');
-  var merklerootbuf = new Buffer(data.merkleroothex, 'hex');
+  var prevblockidbuf = Buffer.from(data.prevblockidhex, 'hex');
+  var merklerootbuf = Buffer.from(data.merkleroothex, 'hex');
   var time = data.time;
   var bits = data.bits;
   var nonce = data.nonce;
@@ -35,7 +35,7 @@ describe('BlockHeader', function() {
     nonce: nonce
   });
   var bhhex = data.blockheaderhex;
-  var bhbuf = new Buffer(bhhex, 'hex');
+  var bhbuf = Buffer.from(bhhex, 'hex');
 
   it('should make a new blockheader', function() {
     BlockHeader(bhbuf).toBuffer().toString('hex').should.equal(bhhex);
@@ -85,7 +85,7 @@ describe('BlockHeader', function() {
   describe('version', function() {
     it('is interpreted as an int32le', function() {
       var hex = 'ffffffff00000000000000000000000000000000000000000000000000000000000000004141414141414141414141414141414141414141414141414141414141414141010000000200000003000000';
-      var header = BlockHeader.fromBuffer(new Buffer(hex, 'hex'));
+      var header = BlockHeader.fromBuffer(Buffer.from(hex, 'hex'));
       header.version.should.equal(-1);
       header.timestamp.should.equal(1);
     });

--- a/test/block/merkleblock.js
+++ b/test/block/merkleblock.js
@@ -16,7 +16,7 @@ var transactionVector = require('../data/tx_creation');
 
 describe('MerkleBlock', function() {
   var blockhex  = data.HEX[0];
-  var blockbuf  = new Buffer(blockhex,'hex');
+  var blockbuf  = Buffer.from(blockhex,'hex');
   var blockJSON = JSON.stringify(data.JSON[0]);
   var blockObject = JSON.parse(JSON.stringify(data.JSON[0]));
 
@@ -159,7 +159,7 @@ describe('MerkleBlock', function() {
 
     it('should find transactions via hash string', function() {
       var jsonData = data.JSON[1];
-      var txId = new Buffer(jsonData.hashes[2],'hex').toString('hex');
+      var txId = Buffer.from(jsonData.hashes[2],'hex').toString('hex');
       var b = MerkleBlock(jsonData);
       b.hasTransaction(txId).should.equal(true);
       b.hasTransaction(txId + 'abcd').should.equal(false);
@@ -167,7 +167,7 @@ describe('MerkleBlock', function() {
 
     it('should find transactions via Transaction object', function() {
       var jsonData = data.JSON[1];
-      var txBuf = new Buffer(data.TXHEX[0][1],'hex');
+      var txBuf = Buffer.from(data.TXHEX[0][1],'hex');
       var tx = new Transaction().fromBuffer(txBuf);
       var b = MerkleBlock(jsonData);
       b.hasTransaction(tx).should.equal(true);
@@ -176,7 +176,7 @@ describe('MerkleBlock', function() {
     it('should not find non-existant Transaction object', function() {
       // Reuse another transaction already in data/ dir
       var serialized = transactionVector[0][9];
-      var tx = new Transaction().fromBuffer(new Buffer(serialized, 'hex'));
+      var tx = new Transaction().fromBuffer(Buffer.from(serialized, 'hex'));
       var b = MerkleBlock(data.JSON[0]);
       b.hasTransaction(tx).should.equal(false);
     });

--- a/test/crypto/bn.js
+++ b/test/crypto/bn.js
@@ -97,21 +97,21 @@ describe('BN', function() {
   describe('@fromBuffer', function() {
 
     it('should work with big endian', function() {
-      var bn = BN.fromBuffer(new Buffer('0001', 'hex'), {
+      var bn = BN.fromBuffer(Buffer.from('0001', 'hex'), {
         endian: 'big'
       });
       bn.toString().should.equal('1');
     });
 
     it('should work with big endian 256', function() {
-      var bn = BN.fromBuffer(new Buffer('0100', 'hex'), {
+      var bn = BN.fromBuffer(Buffer.from('0100', 'hex'), {
         endian: 'big'
       });
       bn.toString().should.equal('256');
     });
 
     it('should work with little endian if we specify the size', function() {
-      var bn = BN.fromBuffer(new Buffer('0100', 'hex'), {
+      var bn = BN.fromBuffer(Buffer.from('0100', 'hex'), {
         size: 2,
         endian: 'little'
       });

--- a/test/crypto/ecdsa.js
+++ b/test/crypto/ecdsa.js
@@ -21,9 +21,9 @@ describe('ECDSA', function() {
   });
 
   var ecdsa = new ECDSA();
-  ecdsa.hashbuf = Hash.sha256(new Buffer('test data'));
+  ecdsa.hashbuf = Hash.sha256(Buffer.from('test data'));
   ecdsa.privkey = new Privkey(BN.fromBuffer(
-    new Buffer('fee0a1f7afebf9d2a5a80c0c98a31c709681cce195cbcd06342b517970c0be1e', 'hex')
+    Buffer.from('fee0a1f7afebf9d2a5a80c0c98a31c709681cce195cbcd06342b517970c0be1e', 'hex')
   ));
   ecdsa.privkey2pubkey();
 
@@ -44,11 +44,11 @@ describe('ECDSA', function() {
     });
 
     it('calulates this known i', function() {
-      var hashbuf = Hash.sha256(new Buffer('some data'));
+      var hashbuf = Hash.sha256(Buffer.from('some data'));
       var r = new BN('71706645040721865894779025947914615666559616020894583599959600180037551395766', 10);
       var s = new BN('109412465507152403114191008482955798903072313614214706891149785278625167723646', 10);
       var ecdsa = new ECDSA({
-        privkey: new Privkey(BN.fromBuffer(Hash.sha256(new Buffer('test')))),
+        privkey: new Privkey(BN.fromBuffer(Hash.sha256(Buffer.from('test')))),
         hashbuf: hashbuf,
         sig: new Signature({
           r: r,
@@ -112,7 +112,7 @@ describe('ECDSA', function() {
       // test fixture from bitcoinjs
       // https://github.com/bitcoinjs/bitcoinjs-lib/blob/10630873ebaa42381c5871e20336fbfb46564ac8/test/fixtures/ecdsa.json#L6
       var ecdsa = new ECDSA();
-      ecdsa.hashbuf = Hash.sha256(new Buffer('Everything should be made as simple as possible, but not simpler.'));
+      ecdsa.hashbuf = Hash.sha256(Buffer.from('Everything should be made as simple as possible, but not simpler.'));
       ecdsa.privkey = new Privkey(new BN(1));
       ecdsa.privkey2pubkey();
       ecdsa.deterministicK();
@@ -165,8 +165,8 @@ describe('ECDSA', function() {
 
     it('should return an error if r, s are invalid', function() {
       var ecdsa = new ECDSA();
-      ecdsa.hashbuf = Hash.sha256(new Buffer('test'));
-      var pk = Pubkey.fromDER(new Buffer('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49' +
+      ecdsa.hashbuf = Hash.sha256(Buffer.from('test'));
+      var pk = Pubkey.fromDER(Buffer.from('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49' +
         '710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341', 'hex'));
       ecdsa.pubkey = pk;
       ecdsa.sig = new Signature();
@@ -215,9 +215,9 @@ describe('ECDSA', function() {
     });
 
     it('should generate right K', function() {
-      var msg1 = new Buffer('52204d20fd0131ae1afd173fd80a3a746d2dcc0cddced8c9dc3d61cc7ab6e966', 'hex');
-      var msg2 = [].reverse.call(new Buffer(msg1))
-      var pk = new Buffer('16f243e962c59e71e54189e67e66cf2440a1334514c09c00ddcc21632bac9808', 'hex');
+      var msg1 = Buffer.from('52204d20fd0131ae1afd173fd80a3a746d2dcc0cddced8c9dc3d61cc7ab6e966', 'hex');
+      var msg2 = [].reverse.call(Buffer.from(msg1))
+      var pk = Buffer.from('16f243e962c59e71e54189e67e66cf2440a1334514c09c00ddcc21632bac9808', 'hex');
       var signature1 = ECDSA.sign(msg1, Privkey.fromBuffer(pk)).toBuffer().toString('hex');
       var signature2 = ECDSA.sign(msg2, Privkey.fromBuffer(pk), 'little').toBuffer().toString('hex');
       signature1.should.equal(signature2);
@@ -278,9 +278,9 @@ describe('ECDSA', function() {
       vectors.valid.forEach(function(obj, i) {
         it('should validate valid vector ' + i, function() {
           var ecdsa = ECDSA().set({
-            privkey: new Privkey(BN.fromBuffer(new Buffer(obj.d, 'hex'))),
-            k: BN.fromBuffer(new Buffer(obj.k, 'hex')),
-            hashbuf: Hash.sha256(new Buffer(obj.message)),
+            privkey: new Privkey(BN.fromBuffer(Buffer.from(obj.d, 'hex'))),
+            k: BN.fromBuffer(Buffer.from(obj.k, 'hex')),
+            hashbuf: Hash.sha256(Buffer.from(obj.message)),
             sig: new Signature().set({
               r: new BN(obj.signature.r),
               s: new BN(obj.signature.s),
@@ -303,7 +303,7 @@ describe('ECDSA', function() {
           var ecdsa = ECDSA().set({
             pubkey: Pubkey.fromPoint(point.fromX(true, 1)),
             sig: new Signature(new BN(obj.signature.r), new BN(obj.signature.s)),
-            hashbuf: Hash.sha256(new Buffer(obj.message))
+            hashbuf: Hash.sha256(Buffer.from(obj.message))
           });
           ecdsa.sigError().should.equal(obj.exception);
         });
@@ -311,8 +311,8 @@ describe('ECDSA', function() {
 
       vectors.deterministicK.forEach(function(obj, i) {
         it('should validate deterministicK vector ' + i, function() {
-          var hashbuf = Hash.sha256(new Buffer(obj.message));
-          var privkey = Privkey(BN.fromBuffer(new Buffer(obj.privkey, 'hex')), 'mainnet');
+          var hashbuf = Hash.sha256(Buffer.from(obj.message));
+          var privkey = Privkey(BN.fromBuffer(Buffer.from(obj.privkey, 'hex')), 'mainnet');
           var ecdsa = ECDSA({
             privkey: privkey,
             hashbuf: hashbuf

--- a/test/crypto/hash.js
+++ b/test/crypto/hash.js
@@ -8,7 +8,7 @@ var bitcore = require('../..');
 var Hash = bitcore.crypto.Hash;
 
 describe('Hash', function() {
-  var buf = new Buffer([0, 1, 2, 3, 253, 254, 255]);
+  var buf = Buffer.from([0, 1, 2, 3, 253, 254, 255]);
   var str = 'test string';
 
   describe('@sha1', function() {
@@ -16,7 +16,7 @@ describe('Hash', function() {
     it('calculates the hash of this buffer correctly', function() {
       var hash = Hash.sha1(buf);
       hash.toString('hex').should.equal('de69b8a4a5604d0486e6420db81e39eb464a17b2');
-      hash = Hash.sha1(new Buffer(0));
+      hash = Hash.sha1(Buffer.alloc(0));
       hash.toString('hex').should.equal('da39a3ee5e6b4b0d3255bfef95601890afd80709');
     });
 
@@ -42,25 +42,25 @@ describe('Hash', function() {
   describe('#sha256hmac', function() {
 
     it('computes this known big key correctly', function() {
-      var key = new Buffer('b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad' +
+      var key = Buffer.from('b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad' +
         'b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad' +
         'b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad' +
         'b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad');
-      var data = new Buffer('');
+      var data = Buffer.from('');
       Hash.sha256hmac(data, key).toString('hex')
         .should.equal('fb1f87218671f1c0c4593a88498e02b6dfe8afd814c1729e89a1f1f6600faa23');
     });
 
     it('computes this known empty test vector correctly', function() {
-      var key = new Buffer('');
-      var data = new Buffer('');
+      var key = Buffer.from('');
+      var data = Buffer.from('');
       Hash.sha256hmac(data, key).toString('hex')
         .should.equal('b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad');
     });
 
     it('computes this known non-empty test vector correctly', function() {
-      var key = new Buffer('key');
-      var data = new Buffer('The quick brown fox jumps over the lazy dog');
+      var key = Buffer.from('key');
+      var data = Buffer.from('The quick brown fox jumps over the lazy dog');
       Hash.sha256hmac(data, key).toString('hex')
         .should.equal('f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8');
     });
@@ -126,14 +126,14 @@ describe('Hash', function() {
     it('calculates this known empty test vector correctly', function() {
       var hex = 'b936cee86c9f87aa5d3c6f2e84cb5a4239a5fe50480a6ec66b70ab5b1f4a' +
         'c6730c6c515421b327ec1d69402e53dfb49ad7381eb067b338fd7b0cb22247225d47';
-      Hash.sha512hmac(new Buffer([]), new Buffer([])).toString('hex').should.equal(hex);
+      Hash.sha512hmac(Buffer.from([]), Buffer.from([])).toString('hex').should.equal(hex);
     });
 
     it('calculates this known non-empty test vector correctly', function() {
       var hex = 'c40bd7c15aa493b309c940e08a73ffbd28b2e4cb729eb94480d727e4df577' +
         'b13cc403a78e6150d83595f3b17c4cc331f12ca5952691de3735a63c1d4c69a2bac';
-      var data = new Buffer('test1');
-      var key = new Buffer('test2');
+      var data = Buffer.from('test1');
+      var key = Buffer.from('test2');
       Hash.sha512hmac(data, key).toString('hex').should.equal(hex);
     });
 

--- a/test/crypto/point.js
+++ b/test/crypto/point.js
@@ -42,7 +42,7 @@ describe('Point', function() {
       var p = Point(valid.x,valid.y);
       var a = p.getX().toBuffer({size: 32});
       a.length.should.equal(32);
-      a.should.deep.equal(new Buffer(valid.x, 'hex'));
+      a.should.deep.equal(Buffer.from(valid.x, 'hex'));
     });
 
   });
@@ -58,7 +58,7 @@ describe('Point', function() {
       var p = Point(valid.x,valid.y);
       var a = p.getY().toBuffer({size: 32});
       a.length.should.equal(32);
-      a.should.deep.equal(new Buffer(valid.y, 'hex'));
+      a.should.deep.equal(Buffer.from(valid.y, 'hex'));
     });
 
   });

--- a/test/crypto/signature.js
+++ b/test/crypto/signature.js
@@ -202,7 +202,7 @@ describe('Signature', function() {
 
     it('should parse this signature from script_valid.json', function() {
       var sighex = '304502203e4516da7253cf068effec6b95c41221c0cf3a8e6ccb8cbf1725b562e9afde2c022100ab1e3da73d67e32045a20e0b999e049978ea8d6ee5480d485fcf2ce0d03b2ef051';
-      var sig = Buffer(sighex, 'hex');
+      var sig = Buffer.from(sighex, 'hex');
       var parsed = Signature.parseDER(sig, false);
       should.exist(parsed);
     });

--- a/test/crypto/signature.js
+++ b/test/crypto/signature.js
@@ -54,10 +54,10 @@ describe('Signature', function() {
   describe('#fromCompact', function() {
 
     it('should create a signature from a compressed signature', function() {
-      var blank = new Buffer(32);
+      var blank = Buffer.alloc(32);
       blank.fill(0);
       var compressed = Buffer.concat([
-        new Buffer([0 + 27 + 4]),
+        Buffer.from([0 + 27 + 4]),
         blank,
         blank
       ]);
@@ -70,7 +70,7 @@ describe('Signature', function() {
     it('should create a signature from an uncompressed signature', function() {
       var sigHexaStr = '1cd5e61ab5bfd0d1450997894cb1a53e917f89d82eb43f06fa96f32c96e061aec12fc1188e8b' +
         '0dc553a2588be2b5b68dbbd7f092894aa3397786e9c769c5348dc6';
-      var sig = Signature.fromCompact(new Buffer(sigHexaStr, 'hex'));
+      var sig = Signature.fromCompact(Buffer.from(sigHexaStr, 'hex'));
       var r = 'd5e61ab5bfd0d1450997894cb1a53e917f89d82eb43f06fa96f32c96e061aec1';
       var s = '2fc1188e8b0dc553a2588be2b5b68dbbd7f092894aa3397786e9c769c5348dc6';
       sig.r.toString('hex').should.equal(r);
@@ -82,7 +82,7 @@ describe('Signature', function() {
 
   describe('#fromDER', function() {
 
-    var buf = new Buffer('3044022075fc517e541bd54769c080b64397e32161c850f6c1b2b67a5c433affbb3e62770220729e85cc46ffab881065ec07694220e71d4df9b2b8c8fd12c3122cf3a5efbcf2', 'hex');
+    var buf = Buffer.from('3044022075fc517e541bd54769c080b64397e32161c850f6c1b2b67a5c433affbb3e62770220729e85cc46ffab881065ec07694220e71d4df9b2b8c8fd12c3122cf3a5efbcf2', 'hex');
 
     it('should parse this DER format signature', function() {
       var sig = Signature.fromDER(buf);
@@ -98,7 +98,7 @@ describe('Signature', function() {
 
   describe('#fromString', function() {
 
-    var buf = new Buffer('3044022075fc517e541bd54769c080b64397e32161c850f6c1b2b67a5c433affbb3e62770220729e85cc46ffab881065ec07694220e71d4df9b2b8c8fd12c3122cf3a5efbcf2', 'hex');
+    var buf = Buffer.from('3044022075fc517e541bd54769c080b64397e32161c850f6c1b2b67a5c433affbb3e62770220729e85cc46ffab881065ec07694220e71d4df9b2b8c8fd12c3122cf3a5efbcf2', 'hex');
 
     it('should parse this DER format signature in hex', function() {
       var sig = Signature.fromString(buf.toString('hex'));
@@ -116,7 +116,7 @@ describe('Signature', function() {
 
     it('should parse this known signature and rebuild it with updated zero-padded sighash types', function() {
       var original = '30450221008bab1f0a2ff2f9cb8992173d8ad73c229d31ea8e10b0f4d4ae1a0d8ed76021fa02200993a6ec81755b9111762fc2cf8e3ede73047515622792110867d12654275e7201';
-      var buf = new Buffer(original, 'hex');
+      var buf = Buffer.from(original, 'hex');
       var sig = Signature.fromTxFormat(buf);
       sig.nhashtype.should.equal(Signature.SIGHASH_ALL);
       sig.set({
@@ -134,7 +134,7 @@ describe('Signature', function() {
   describe('#fromTxFormat', function() {
 
     it('should convert from this known tx-format buffer', function() {
-      var buf = new Buffer('30450221008bab1f0a2ff2f9cb8992173d8ad73c229d31ea8e10b0f4d4ae1a0d8ed76021fa02200993a6ec81755b9111762fc2cf8e3ede73047515622792110867d12654275e7201', 'hex');
+      var buf = Buffer.from('30450221008bab1f0a2ff2f9cb8992173d8ad73c229d31ea8e10b0f4d4ae1a0d8ed76021fa02200993a6ec81755b9111762fc2cf8e3ede73047515622792110867d12654275e7201', 'hex');
       var sig = Signature.fromTxFormat(buf);
       sig.r.toString().should.equal('63173831029936981022572627018246571655303050627048489594159321588908385378810');
       sig.s.toString().should.equal('4331694221846364448463828256391194279133231453999942381442030409253074198130');
@@ -143,7 +143,7 @@ describe('Signature', function() {
 
     it('should parse this known signature and rebuild it', function() {
       var hex = '3044022007415aa37ce7eaa6146001ac8bdefca0ddcba0e37c5dc08c4ac99392124ebac802207d382307fd53f65778b07b9c63b6e196edeadf0be719130c5db21ff1e700d67501';
-      var buf = new Buffer(hex, 'hex');
+      var buf = Buffer.from(hex, 'hex');
       var sig = Signature.fromTxFormat(buf);
       sig.toTxFormat().toString('hex').should.equal(hex);
     });
@@ -154,7 +154,7 @@ describe('Signature', function() {
 
     it('should parse this signature generated in node', function() {
       var sighex = '30450221008bab1f0a2ff2f9cb8992173d8ad73c229d31ea8e10b0f4d4ae1a0d8ed76021fa02200993a6ec81755b9111762fc2cf8e3ede73047515622792110867d12654275e72';
-      var sig = new Buffer(sighex, 'hex');
+      var sig = Buffer.from(sighex, 'hex');
       var parsed = Signature.parseDER(sig);
       parsed.header.should.equal(0x30);
       parsed.length.should.equal(69);
@@ -170,7 +170,7 @@ describe('Signature', function() {
 
     it('should parse this 69 byte signature', function() {
       var sighex = '3043021f59e4705959cc78acbfcf8bd0114e9cc1b389a4287fb33152b73a38c319b50302202f7428a27284c757e409bf41506183e9e49dfb54d5063796dfa0d403a4deccfa';
-      var sig = new Buffer(sighex, 'hex');
+      var sig = Buffer.from(sighex, 'hex');
       var parsed = Signature.parseDER(sig);
       parsed.header.should.equal(0x30);
       parsed.length.should.equal(67);
@@ -186,7 +186,7 @@ describe('Signature', function() {
 
     it('should parse this 68 byte signature', function() {
       var sighex = '3042021e17cfe77536c3fb0526bd1a72d7a8e0973f463add210be14063c8a9c37632022061bfa677f825ded82ba0863fb0c46ca1388dd3e647f6a93c038168b59d131a51';
-      var sig = new Buffer(sighex, 'hex');
+      var sig = Buffer.from(sighex, 'hex');
       var parsed = Signature.parseDER(sig);
       parsed.header.should.equal(0x30);
       parsed.length.should.equal(66);
@@ -241,14 +241,14 @@ describe('Signature', function() {
   describe('@isTxDER', function() {
     it('should know this is a DER signature', function() {
       var sighex = '3042021e17cfe77536c3fb0526bd1a72d7a8e0973f463add210be14063c8a9c37632022061bfa677f825ded82ba0863fb0c46ca1388dd3e647f6a93c038168b59d131a5101';
-      var sigbuf = new Buffer(sighex, 'hex');
+      var sigbuf = Buffer.from(sighex, 'hex');
       Signature.isTxDER(sigbuf).should.equal(true);
     });
 
     it('should know this is not a DER signature', function() {
       //for more extensive tests, see the script interpreter
       var sighex = '3042021e17cfe77536c3fb0526bd1a72d7a8e0973f463add210be14063c8a9c37632022061bfa677f825ded82ba0863fb0c46ca1388dd3e647f6a93c038168b59d131a5101';
-      var sigbuf = new Buffer(sighex, 'hex');
+      var sigbuf = Buffer.from(sighex, 'hex');
       sigbuf[0] = 0x31;
       Signature.isTxDER(sigbuf).should.equal(false);
     });
@@ -267,7 +267,7 @@ describe('Signature', function() {
             var interp = Interpreter();
             interp.flags = Interpreter.SCRIPT_VERIFY_DERSIG |
               Interpreter.SCRIPT_VERIFY_STRICTENC;
-            var result = interp.checkSignatureEncoding(new Buffer(sighex, 'hex'));
+            var result = interp.checkSignatureEncoding(Buffer.from(sighex, 'hex'));
             result.should.equal(expected);
           });
           i++;
@@ -285,22 +285,22 @@ describe('Signature', function() {
       var sig = new Signature({
         r: r,
         s: new BN('7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A1', 'hex')
-      });            
+      });
       sig.hasLowS().should.equal(false);
 
       var sig2 = new Signature({
         r: r,
         s: new BN('7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0', 'hex')
-      });      
+      });
       sig2.hasLowS().should.equal(true);
 
       var sig3 = new Signature({
         r: r,
         s: new BN(1)
-      });      
+      });
       sig3.hasLowS().should.equal(true);
 
-      var sig4 = new Signature({        
+      var sig4 = new Signature({
         r: r,
         s: new BN(0)
       });

--- a/test/encoding/base58.js
+++ b/test/encoding/base58.js
@@ -5,11 +5,10 @@
 
 var should = require('chai').should();
 var bitcore = require('../..');
-var buffer = require('buffer');
 var Base58 = bitcore.encoding.Base58;
 
 describe('Base58', function() {
-  var buf = new buffer.Buffer([0, 1, 2, 3, 253, 254, 255]);
+  var buf = Buffer.from([0, 1, 2, 3, 253, 254, 255]);
   var enc = '1W7N4RuG';
 
   it('should make an instance with "new"', function() {
@@ -24,7 +23,7 @@ describe('Base58', function() {
   });
   it('validates characters from buffer', function() {
     Base58.validCharacters(
-      new buffer.Buffer('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz')
+      Buffer.from('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz')
     ).should.equal(true);
   });
 
@@ -46,7 +45,7 @@ describe('Base58', function() {
 
     it('should set a blank buffer', function() {
       Base58().set({
-        buf: new buffer.Buffer([])
+        buf: Buffer.from([])
       });
     });
 

--- a/test/encoding/base58check.js
+++ b/test/encoding/base58check.js
@@ -9,7 +9,7 @@ var Base58Check = bitcore.encoding.Base58Check;
 var Base58 = bitcore.encoding.Base58;
 
 describe('Base58Check', function() {
-  var buf = new Buffer([0, 1, 2, 3, 253, 254, 255]);
+  var buf = Buffer.from([0, 1, 2, 3, 253, 254, 255]);
   var enc = '14HV44ipwoaqfg';
 
   it('should make an instance with "new"', function() {
@@ -35,7 +35,7 @@ describe('Base58Check', function() {
   });
 
   describe('#set', function() {
-    
+
     it('should set a buf', function() {
       should.exist(Base58Check().set({buf: buf}).buf);
     });
@@ -86,7 +86,7 @@ describe('Base58Check', function() {
   });
 
   describe('#fromBuffer', function() {
-    
+
     it('should not fail', function() {
       should.exist(Base58Check().fromBuffer(buf));
     });

--- a/test/encoding/bufferreader.js
+++ b/test/encoding/bufferreader.js
@@ -19,7 +19,7 @@ describe('BufferReader', function() {
   });
 
   it('should create a new bufferreader with a buffer', function() {
-    var buf = new Buffer(0);
+    var buf = Buffer.alloc(0);
     var br = new BufferReader(buf);
     should.exist(br);
     Buffer.isBuffer(br.buf).should.equal(true);
@@ -44,7 +44,7 @@ describe('BufferReader', function() {
   describe('#eof', function() {
 
     it('should return true for a blank br', function() {
-      var br = new BufferReader(new Buffer([]));
+      var br = new BufferReader(Buffer.from([]));
       br.finished().should.equal(true);
     });
 
@@ -53,13 +53,13 @@ describe('BufferReader', function() {
   describe('read', function() {
 
     it('should return the same buffer', function() {
-      var buf = new Buffer([0]);
+      var buf = Buffer.from([0]);
       var br = new BufferReader(buf);
       br.readAll().toString('hex').should.equal(buf.toString('hex'));
     });
 
     it('should return a buffer of this length', function() {
-      var buf = new Buffer(10);
+      var buf = Buffer.alloc(10);
       buf.fill(0);
       var br = new BufferReader(buf);
       var buf2 = br.read(2);
@@ -69,7 +69,7 @@ describe('BufferReader', function() {
     });
 
     it('should work with 0 length', function() {
-      var buf = new Buffer(10);
+      var buf = Buffer.alloc(10);
       buf.fill(1);
       var br = new BufferReader(buf);
       var buf2 = br.read(0);
@@ -83,7 +83,7 @@ describe('BufferReader', function() {
   describe('readVarLengthBuffer', function() {
 
     it('returns correct buffer', function() {
-      var buf = new Buffer('73010000003766404f00000000b305434f00000000f203' +
+      var buf = Buffer.from('73010000003766404f00000000b305434f00000000f203' +
         '0000f1030000001027000048ee00000064000000004653656520626974636f696' +
         'e2e6f72672f666562323020696620796f7520686176652074726f75626c652063' +
         '6f6e6e656374696e6720616674657220323020466562727561727900473045022' +
@@ -102,7 +102,7 @@ describe('BufferReader', function() {
         '6b684bde2b3f573060d5b70c3a46723326e4e8a4f1');
     });
     it('fails on length too big', function() {
-      var buf = new Buffer('0a00', 'hex');
+      var buf = Buffer.from('0a00', 'hex');
       var br = new BufferReader(buf);
       br.readVarLengthBuffer.bind(br).should.throw('Invalid length while reading varlength buffer');
     });
@@ -112,7 +112,7 @@ describe('BufferReader', function() {
   describe('#readUInt8', function() {
 
     it('should return 1', function() {
-      var buf = new Buffer(1);
+      var buf = Buffer.alloc(1);
       buf.writeUInt8(1, 0);
       var br = new BufferReader(buf);
       br.readUInt8().should.equal(1);
@@ -123,7 +123,7 @@ describe('BufferReader', function() {
   describe('#readUInt16BE', function() {
 
     it('should return 1', function() {
-      var buf = new Buffer(2);
+      var buf = Buffer.alloc(2);
       buf.writeUInt16BE(1, 0);
       var br = new BufferReader(buf);
       br.readUInt16BE().should.equal(1);
@@ -134,7 +134,7 @@ describe('BufferReader', function() {
   describe('#readUInt16LE', function() {
 
     it('should return 1', function() {
-      var buf = new Buffer(2);
+      var buf = Buffer.alloc(2);
       buf.writeUInt16LE(1, 0);
       var br = new BufferReader(buf);
       br.readUInt16LE().should.equal(1);
@@ -145,7 +145,7 @@ describe('BufferReader', function() {
   describe('#readUInt32BE', function() {
 
     it('should return 1', function() {
-      var buf = new Buffer(4);
+      var buf = Buffer.alloc(4);
       buf.writeUInt32BE(1, 0);
       var br = new BufferReader(buf);
       br.readUInt32BE().should.equal(1);
@@ -156,7 +156,7 @@ describe('BufferReader', function() {
   describe('#readUInt32LE', function() {
 
     it('should return 1', function() {
-      var buf = new Buffer(4);
+      var buf = Buffer.alloc(4);
       buf.writeUInt32LE(1, 0);
       var br = new BufferReader(buf);
       br.readUInt32LE().should.equal(1);
@@ -167,7 +167,7 @@ describe('BufferReader', function() {
   describe('#readUInt64BEBN', function() {
 
     it('should return 1', function() {
-      var buf = new Buffer(8);
+      var buf = Buffer.alloc(8);
       buf.fill(0);
       buf.writeUInt32BE(1, 4);
       var br = new BufferReader(buf);
@@ -175,7 +175,7 @@ describe('BufferReader', function() {
     });
 
     it('should return 2^64', function() {
-      var buf = new Buffer(8);
+      var buf = Buffer.alloc(8);
       buf.fill(0xff);
       var br = new BufferReader(buf);
       br.readUInt64BEBN().toNumber().should.equal(Math.pow(2, 64));
@@ -186,7 +186,7 @@ describe('BufferReader', function() {
   describe('#readUInt64LEBN', function() {
 
     it('should return 1', function() {
-      var buf = new Buffer(8);
+      var buf = Buffer.alloc(8);
       buf.fill(0);
       buf.writeUInt32LE(1, 0);
       var br = new BufferReader(buf);
@@ -195,13 +195,13 @@ describe('BufferReader', function() {
 
     it('should return 10BTC', function() {
       var tenbtc = 10 * 1e8;
-      var tenbtcBuffer = new Buffer('00ca9a3b00000000', 'hex');
+      var tenbtcBuffer = Buffer.from('00ca9a3b00000000', 'hex');
       var br = new BufferReader(tenbtcBuffer);
       br.readUInt64LEBN().toNumber().should.equal(tenbtc);
     });
 
     it('should return 2^30', function() {
-      var buf = new Buffer(8);
+      var buf = Buffer.alloc(8);
       buf.fill(0);
       buf.writeUInt32LE(Math.pow(2, 30), 0);
       var br = new BufferReader(buf);
@@ -210,42 +210,42 @@ describe('BufferReader', function() {
 
     it('should return 2^32 + 1', function() {
       var num = Math.pow(2, 32) + 1;
-      var numBuffer = new Buffer('0100000001000000', 'hex');
+      var numBuffer = Buffer.from('0100000001000000', 'hex');
       var br = new BufferReader(numBuffer);
       br.readUInt64LEBN().toNumber().should.equal(num);
     });
 
     it('should return max number of satoshis', function() {
       var maxSatoshis = 21000000 * 1e8;
-      var maxSatoshisBuffer = new Buffer('0040075af0750700', 'hex');
+      var maxSatoshisBuffer = Buffer.from('0040075af0750700', 'hex');
       var br = new BufferReader(maxSatoshisBuffer);
       br.readUInt64LEBN().toNumber().should.equal(maxSatoshis);
     });
 
     it('should return 2^53 - 1', function() {
       var maxSafe = Math.pow(2, 53) - 1;
-      var maxSafeBuffer = new Buffer('ffffffffffff1f00', 'hex');
+      var maxSafeBuffer = Buffer.from('ffffffffffff1f00', 'hex');
       var br = new BufferReader(maxSafeBuffer);
       br.readUInt64LEBN().toNumber().should.equal(maxSafe);
     });
 
     it('should return 2^53', function() {
       var bn = new BN('20000000000000', 16);
-      var bnBuffer = new Buffer('0000000000002000', 'hex');
+      var bnBuffer = Buffer.from('0000000000002000', 'hex');
       var br = new BufferReader(bnBuffer);
       var readbn = br.readUInt64LEBN();
       readbn.cmp(bn).should.equal(0);
     });
 
     it('should return 0', function() {
-      var buf = new Buffer(8);
+      var buf = Buffer.alloc(8);
       buf.fill(0);
       var br = new BufferReader(buf);
       br.readUInt64LEBN().toNumber().should.equal(0);
     });
 
     it('should return 2^64', function() {
-      var buf = new Buffer(8);
+      var buf = Buffer.alloc(8);
       buf.fill(0xff);
       var br = new BufferReader(buf);
       br.readUInt64LEBN().toNumber().should.equal(Math.pow(2, 64));
@@ -256,19 +256,19 @@ describe('BufferReader', function() {
   describe('#readVarintBuf', function() {
 
     it('should read a 1 byte varint', function() {
-      var buf = new Buffer([50]);
+      var buf = Buffer.from([50]);
       var br = new BufferReader(buf);
       br.readVarintBuf().length.should.equal(1);
     });
 
     it('should read a 3 byte varint', function() {
-      var buf = new Buffer([253, 253, 0]);
+      var buf = Buffer.from([253, 253, 0]);
       var br = new BufferReader(buf);
       br.readVarintBuf().length.should.equal(3);
     });
 
     it('should read a 5 byte varint', function() {
-      var buf = new Buffer([254, 0, 0, 0, 0]);
+      var buf = Buffer.from([254, 0, 0, 0, 0]);
       buf.writeUInt32LE(50000, 1);
       var br = new BufferReader(buf);
       br.readVarintBuf().length.should.equal(5);
@@ -285,19 +285,19 @@ describe('BufferReader', function() {
   describe('#readVarintNum', function() {
 
     it('should read a 1 byte varint', function() {
-      var buf = new Buffer([50]);
+      var buf = Buffer.from([50]);
       var br = new BufferReader(buf);
       br.readVarintNum().should.equal(50);
     });
 
     it('should read a 3 byte varint', function() {
-      var buf = new Buffer([253, 253, 0]);
+      var buf = Buffer.from([253, 253, 0]);
       var br = new BufferReader(buf);
       br.readVarintNum().should.equal(253);
     });
 
     it('should read a 5 byte varint', function() {
-      var buf = new Buffer([254, 0, 0, 0, 0]);
+      var buf = Buffer.from([254, 0, 0, 0, 0]);
       buf.writeUInt32LE(50000, 1);
       var br = new BufferReader(buf);
       br.readVarintNum().should.equal(50000);
@@ -324,26 +324,26 @@ describe('BufferReader', function() {
   describe('#readVarintBN', function() {
 
     it('should read a 1 byte varint', function() {
-      var buf = new Buffer([50]);
+      var buf = Buffer.from([50]);
       var br = new BufferReader(buf);
       br.readVarintBN().toNumber().should.equal(50);
     });
 
     it('should read a 3 byte varint', function() {
-      var buf = new Buffer([253, 253, 0]);
+      var buf = Buffer.from([253, 253, 0]);
       var br = new BufferReader(buf);
       br.readVarintBN().toNumber().should.equal(253);
     });
 
     it('should read a 5 byte varint', function() {
-      var buf = new Buffer([254, 0, 0, 0, 0]);
+      var buf = Buffer.from([254, 0, 0, 0, 0]);
       buf.writeUInt32LE(50000, 1);
       var br = new BufferReader(buf);
       br.readVarintBN().toNumber().should.equal(50000);
     });
 
     it('should read a 9 byte varint', function() {
-      var buf = Buffer.concat([new Buffer([255]), new Buffer('ffffffffffffffff', 'hex')]);
+      var buf = Buffer.concat([Buffer.from([255]), Buffer.from('ffffffffffffffff', 'hex')]);
       var br = new BufferReader(buf);
       br.readVarintBN().toNumber().should.equal(Math.pow(2, 64));
     });
@@ -353,7 +353,7 @@ describe('BufferReader', function() {
   describe('#reverse', function() {
 
     it('should reverse this [0, 1]', function() {
-      var buf = new Buffer([0, 1]);
+      var buf = Buffer.from([0, 1]);
       var br = new BufferReader(buf);
       br.reverse().readAll().toString('hex').should.equal('0100');
     });

--- a/test/encoding/bufferwriter.js
+++ b/test/encoding/bufferwriter.js
@@ -17,10 +17,10 @@ describe('BufferWriter', function() {
   });
 
   describe('#set', function() {
-    
+
     it('set bufs', function() {
-      var buf1 = new Buffer([0]);
-      var buf2 = new Buffer([1]);
+      var buf1 = Buffer.from([0]);
+      var buf2 = Buffer.from([1]);
       var bw = new BufferWriter().set({bufs: [buf1, buf2]});
       bw.concat().toString('hex').should.equal('0001');
     });
@@ -28,10 +28,10 @@ describe('BufferWriter', function() {
   });
 
   describe('#toBuffer', function() {
-    
+
     it('should concat these two bufs', function() {
-      var buf1 = new Buffer([0]);
-      var buf2 = new Buffer([1]);
+      var buf1 = Buffer.from([0]);
+      var buf2 = Buffer.from([1]);
       var bw = new BufferWriter({bufs: [buf1, buf2]});
       bw.toBuffer().toString('hex').should.equal('0001');
     });
@@ -39,10 +39,10 @@ describe('BufferWriter', function() {
   });
 
   describe('#concat', function() {
-    
+
     it('should concat these two bufs', function() {
-      var buf1 = new Buffer([0]);
-      var buf2 = new Buffer([1]);
+      var buf1 = Buffer.from([0]);
+      var buf2 = Buffer.from([1]);
       var bw = new BufferWriter({bufs: [buf1, buf2]});
       bw.concat().toString('hex').should.equal('0001');
     });
@@ -52,7 +52,7 @@ describe('BufferWriter', function() {
   describe('#write', function() {
 
     it('should write a buffer', function() {
-      var buf = new Buffer([0]);
+      var buf = Buffer.from([0]);
       var bw = new BufferWriter();
       bw.write(buf);
       bw.concat().toString('hex').should.equal('00');
@@ -61,7 +61,7 @@ describe('BufferWriter', function() {
   });
 
   describe('#writeUInt8', function() {
-    
+
     it('should write 1', function() {
       var bw = new BufferWriter();
       bw.writeUInt8(1).concat().toString('hex').should.equal('01');
@@ -70,7 +70,7 @@ describe('BufferWriter', function() {
   });
 
   describe('#writeUInt16BE', function() {
-    
+
     it('should write 1', function() {
       var bw = new BufferWriter();
       bw.writeUInt16BE(1).concat().toString('hex').should.equal('0001');
@@ -79,7 +79,7 @@ describe('BufferWriter', function() {
   });
 
   describe('#writeUInt16LE', function() {
-    
+
     it('should write 1', function() {
       var bw = new BufferWriter();
       bw.writeUInt16LE(1).concat().toString('hex').should.equal('0100');
@@ -88,7 +88,7 @@ describe('BufferWriter', function() {
   });
 
   describe('#writeUInt32BE', function() {
-    
+
     it('should write 1', function() {
       var bw = new BufferWriter();
       bw.writeUInt32BE(1).concat().toString('hex').should.equal('00000001');
@@ -97,7 +97,7 @@ describe('BufferWriter', function() {
   });
 
   describe('#writeUInt32LE', function() {
-    
+
     it('should write 1', function() {
       var bw = new BufferWriter();
       bw.writeUInt32LE(1).concat().toString('hex').should.equal('01000000');
@@ -106,7 +106,7 @@ describe('BufferWriter', function() {
   });
 
   describe('#writeUInt64BEBN', function() {
-    
+
     it('should write 1', function() {
       var bw = new BufferWriter();
       bw.writeUInt64BEBN(new BN(1)).concat().toString('hex').should.equal('0000000000000001');
@@ -115,7 +115,7 @@ describe('BufferWriter', function() {
   });
 
   describe('#writeUInt64LEBN', function() {
-    
+
     it('should write 1', function() {
       var bw = new BufferWriter();
       bw.writeUInt64LEBN(new BN(1)).concat().toString('hex').should.equal('0100000000000000');
@@ -124,7 +124,7 @@ describe('BufferWriter', function() {
   });
 
   describe('#writeVarint', function() {
-    
+
     it('should write a 1 byte varint', function() {
       var bw = new BufferWriter();
       bw.writeVarintNum(1);
@@ -161,7 +161,7 @@ describe('BufferWriter', function() {
   });
 
   describe('#writeVarintBN', function() {
-    
+
     it('should write a 1 byte varint', function() {
       var bw = new BufferWriter();
       bw.writeVarintBN(new BN(1));

--- a/test/encoding/varint.js
+++ b/test/encoding/varint.js
@@ -13,7 +13,7 @@ var Varint = bitcore.encoding.Varint;
 describe('Varint', function() {
 
   it('should make a new varint', function() {
-    var buf = new Buffer('00', 'hex');
+    var buf = Buffer.from('00', 'hex');
     var varint = new Varint(buf);
     should.exist(varint);
     varint.buf.toString('hex').should.equal('00');
@@ -28,9 +28,9 @@ describe('Varint', function() {
   });
 
   describe('#set', function() {
-    
+
     it('should set a buffer', function() {
-      var buf = new Buffer('00', 'hex');
+      var buf = Buffer.from('00', 'hex');
       var varint = Varint().set({buf: buf});
       varint.buf.toString('hex').should.equal('00');
       varint.set({});
@@ -40,7 +40,7 @@ describe('Varint', function() {
   });
 
   describe('#fromString', function() {
-    
+
     it('should set a buffer', function() {
       var buf = BufferWriter().writeVarintNum(5).concat();
       var varint = Varint().fromString(buf.toString('hex'));
@@ -50,7 +50,7 @@ describe('Varint', function() {
   });
 
   describe('#toString', function() {
-    
+
     it('should return a buffer', function() {
       var buf = BufferWriter().writeVarintNum(5).concat();
       var varint = Varint().fromString(buf.toString('hex'));
@@ -60,7 +60,7 @@ describe('Varint', function() {
   });
 
   describe('#fromBuffer', function() {
-    
+
     it('should set a buffer', function() {
       var buf = BufferWriter().writeVarintNum(5).concat();
       var varint = Varint().fromBuffer(buf);
@@ -70,7 +70,7 @@ describe('Varint', function() {
   });
 
   describe('#fromBufferReader', function() {
-    
+
     it('should set a buffer reader', function() {
       var buf = BufferWriter().writeVarintNum(5).concat();
       var br = BufferReader(buf);
@@ -81,7 +81,7 @@ describe('Varint', function() {
   });
 
   describe('#fromBN', function() {
-    
+
     it('should set a number', function() {
       var varint = Varint().fromBN(new BN(5));
       varint.toNumber().should.equal(5);
@@ -90,7 +90,7 @@ describe('Varint', function() {
   });
 
   describe('#fromNumber', function() {
-    
+
     it('should set a number', function() {
       var varint = Varint().fromNumber(5);
       varint.toNumber().should.equal(5);
@@ -99,7 +99,7 @@ describe('Varint', function() {
   });
 
   describe('#toBuffer', function() {
-    
+
     it('should return a buffer', function() {
       var buf = BufferWriter().writeVarintNum(5).concat();
       var varint = Varint(buf);
@@ -109,7 +109,7 @@ describe('Varint', function() {
   });
 
   describe('#toBN', function() {
-    
+
     it('should return a buffer', function() {
       var varint = Varint(5);
       varint.toBN().toString().should.equal(new BN(5).toString());
@@ -118,7 +118,7 @@ describe('Varint', function() {
   });
 
   describe('#toNumber', function() {
-    
+
     it('should return a buffer', function() {
       var varint = Varint(5);
       varint.toNumber().should.equal(5);

--- a/test/hdkeys.js
+++ b/test/hdkeys.js
@@ -227,8 +227,8 @@ describe('BIP32 compliance', function() {
 
   it('should use full 32 bytes for private key data that is hashed (as per bip32)', function() {
     // https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
-    var privateKeyBuffer = new Buffer('00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd', 'hex');
-    var chainCodeBuffer = new Buffer('9c8a5c863e5941f3d99453e6ba66b328bb17cf0b8dec89ed4fc5ace397a1c089', 'hex');
+    var privateKeyBuffer = Buffer.from('00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd', 'hex');
+    var chainCodeBuffer = Buffer.from('9c8a5c863e5941f3d99453e6ba66b328bb17cf0b8dec89ed4fc5ace397a1c089', 'hex');
     var key = HDPrivateKey.fromObject({
       network: 'testnet',
       depth: 0,
@@ -243,8 +243,8 @@ describe('BIP32 compliance', function() {
 
   it('should NOT use full 32 bytes for private key data that is hashed with nonCompliant flag', function() {
     // This is to test that the previously implemented non-compliant to BIP32
-    var privateKeyBuffer = new Buffer('00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd', 'hex');
-    var chainCodeBuffer = new Buffer('9c8a5c863e5941f3d99453e6ba66b328bb17cf0b8dec89ed4fc5ace397a1c089', 'hex');
+    var privateKeyBuffer = Buffer.from('00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd', 'hex');
+    var chainCodeBuffer = Buffer.from('9c8a5c863e5941f3d99453e6ba66b328bb17cf0b8dec89ed4fc5ace397a1c089', 'hex');
     var key = HDPrivateKey.fromObject({
       network: 'testnet',
       depth: 0,
@@ -259,8 +259,8 @@ describe('BIP32 compliance', function() {
 
   it('should NOT use full 32 bytes for private key data that is hashed with the nonCompliant derive method', function() {
     // This is to test that the previously implemented non-compliant to BIP32
-    var privateKeyBuffer = new Buffer('00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd', 'hex');
-    var chainCodeBuffer = new Buffer('9c8a5c863e5941f3d99453e6ba66b328bb17cf0b8dec89ed4fc5ace397a1c089', 'hex');
+    var privateKeyBuffer = Buffer.from('00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd', 'hex');
+    var chainCodeBuffer = Buffer.from('9c8a5c863e5941f3d99453e6ba66b328bb17cf0b8dec89ed4fc5ace397a1c089', 'hex');
     var key = HDPrivateKey.fromObject({
       network: 'testnet',
       depth: 0,
@@ -279,9 +279,9 @@ describe('BIP32 compliance', function() {
       sandbox.restore();
     });
     it('will handle edge case that derived private key is invalid', function() {
-      var invalid = new Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex');
-      var privateKeyBuffer = new Buffer('5f72914c48581fc7ddeb944a9616389200a9560177d24f458258e5b04527bcd1', 'hex');
-      var chainCodeBuffer = new Buffer('39816057bba9d952fe87fe998b7fd4d690a1bb58c2ff69141469e4d1dffb4b91', 'hex');
+      var invalid = Buffer.from('0000000000000000000000000000000000000000000000000000000000000000', 'hex');
+      var privateKeyBuffer = Buffer.from('5f72914c48581fc7ddeb944a9616389200a9560177d24f458258e5b04527bcd1', 'hex');
+      var chainCodeBuffer = Buffer.from('39816057bba9d952fe87fe998b7fd4d690a1bb58c2ff69141469e4d1dffb4b91', 'hex');
       var unstubbed = bitcore.crypto.BN.prototype.toBuffer;
       var count = 0;
       var stub = sandbox.stub(bitcore.crypto.BN.prototype, 'toBuffer').callsFake(function(args) {
@@ -308,8 +308,8 @@ describe('BIP32 compliance', function() {
       bitcore.PrivateKey.isValid.callCount.should.equal(2);
     });
     it('will handle edge case that a derive public key is invalid', function() {
-      var publicKeyBuffer = new Buffer('029e58b241790284ef56502667b15157b3fc58c567f044ddc35653860f9455d099', 'hex');
-      var chainCodeBuffer = new Buffer('39816057bba9d952fe87fe998b7fd4d690a1bb58c2ff69141469e4d1dffb4b91', 'hex');
+      var publicKeyBuffer = Buffer.from('029e58b241790284ef56502667b15157b3fc58c567f044ddc35653860f9455d099', 'hex');
+      var chainCodeBuffer = Buffer.from('39816057bba9d952fe87fe998b7fd4d690a1bb58c2ff69141469e4d1dffb4b91', 'hex');
       var key = new HDPublicKey({
         network: 'testnet',
         depth: 0,

--- a/test/hdprivatekey.js
+++ b/test/hdprivatekey.js
@@ -10,7 +10,6 @@ var expect = require('chai').expect;
 var bitcore = require('..');
 var errors = bitcore.errors;
 var hdErrors = errors.HDPrivateKey;
-var buffer = require('buffer');
 var Networks = bitcore.Networks;
 var BufferUtil = bitcore.util.buffer;
 var HDPrivateKey = bitcore.HDPrivateKey;
@@ -143,7 +142,7 @@ describe('HDPrivate key interface', function() {
   });
 
   it('returns InvalidLength if data of invalid length is given to getSerializedError', function() {
-    var b58s = Base58Check.encode(new buffer.Buffer('onestring'));
+    var b58s = Base58Check.encode(Buffer.from('onestring'));
     expect(
       HDPrivateKey.getSerializedError(b58s) instanceof hdErrors.InvalidLength
     ).to.equal(true);

--- a/test/hdpublickey.js
+++ b/test/hdpublickey.js
@@ -9,11 +9,9 @@ var assert = require('assert');
 var should = require('chai').should();
 var expect = require('chai').expect;
 var bitcore = require('..');
-var buffer = require('buffer');
 var errors = bitcore.errors;
 var hdErrors = bitcore.errors.HDPublicKey;
 var BufferUtil = bitcore.util.buffer;
-var HDPrivateKey = bitcore.HDPrivateKey;
 var HDPublicKey = bitcore.HDPublicKey;
 var Base58Check = bitcore.encoding.Base58Check;
 var Networks = bitcore.Networks;
@@ -81,7 +79,7 @@ describe('HDPublicKey interface', function() {
     describe('xpubkey string serialization errors', function() {
       it('fails on invalid length', function() {
         expectFailBuilding(
-          Base58Check.encode(new buffer.Buffer([1, 2, 3])),
+          Base58Check.encode(Buffer.from([1, 2, 3])),
           hdErrors.InvalidLength
         );
       });

--- a/test/message.js
+++ b/test/message.js
@@ -22,8 +22,8 @@ describe('Message', function() {
 
   var badSignatureString = 'H69qZ4mbZCcvXk7CWjptD5ypnYVLvQ3eMXLM8+1gX21SLH/GaFnAjQrDn37+TDw79i9zHhbiMMwhtvTwnPigZ6k=';
 
-  var signature = Signature.fromCompact(new Buffer(signatureString, 'base64'));
-  var badSignature = Signature.fromCompact(new Buffer(badSignatureString, 'base64'));
+  var signature = Signature.fromCompact(Buffer.from(signatureString, 'base64'));
+  var badSignature = Signature.fromCompact(Buffer.from(badSignatureString, 'base64'));
 
   var publicKey = privateKey.toPublicKey();
 

--- a/test/mnemonic/mnemonic.unit.js
+++ b/test/mnemonic/mnemonic.unit.js
@@ -6,7 +6,7 @@
 var chai = require('chai');
 var should = chai.should();
 
-var {Mnemonic} = require('../../index');
+var Mnemonic = require('../../index').Mnemonic;
 var errors = require('../../lib/mnemonic/errors');
 var bip39_vectors = require('./data/fixtures.json');
 
@@ -169,7 +169,7 @@ describe('Mnemonic', function() {
 
     it('Mnemonic.fromSeed should fail with invalid wordlist', function() {
       (function() {
-        return Mnemonic.fromSeed(new Buffer(1));
+        return Mnemonic.fromSeed(Buffer.alloc(1));
       }).should.throw(errors.InvalidArgument);
     });
 
@@ -181,7 +181,7 @@ describe('Mnemonic', function() {
 
     it('Constructor should fail with invalid seed', function() {
       (function() {
-        return new Mnemonic(new Buffer(1));
+        return new Mnemonic(Buffer.alloc(1));
       }).should.throw(errors.InvalidEntropy);
     });
 
@@ -203,7 +203,7 @@ describe('Mnemonic', function() {
         var code = vector[1];
         var mnemonic = vector[2];
         var seed = vector[3];
-        var mnemonic1 = Mnemonic.fromSeed(new Buffer(code, 'hex'), wordlist).phrase;
+        var mnemonic1 = Mnemonic.fromSeed(Buffer.from(code, 'hex'), wordlist).phrase;
         mnemonic1.should.equal(mnemonic);
 
         var m = new Mnemonic(mnemonic);

--- a/test/networks.js
+++ b/test/networks.js
@@ -20,13 +20,13 @@ describe('Networks', function() {
 
   it('will enable/disable regtest Network', function() {
     networks.enableRegtest();
-    networks.testnet.networkMagic.should.deep.equal(new Buffer('fcc1b7dc', 'hex'));
+    networks.testnet.networkMagic.should.deep.equal(Buffer.from('fcc1b7dc', 'hex'));
     networks.testnet.port.should.equal(19994);
     networks.testnet.dnsSeeds.should.deep.equal([]);
     networks.testnet.regtestEnabled.should.equal(true);
 
     networks.disableRegtest();
-    networks.testnet.networkMagic.should.deep.equal(new Buffer('cee2caff', 'hex'));
+    networks.testnet.networkMagic.should.deep.equal(Buffer.from('cee2caff', 'hex'));
     networks.testnet.port.should.equal(19999);
     networks.testnet.dnsSeeds.should.deep.equal([
      'testnet-seed.darkcoin.io',
@@ -62,7 +62,7 @@ describe('Networks', function() {
       if (key !== 'networkMagic') {
         customnet[key].should.equal(custom[key]);
       } else {
-        var expected = new Buffer('e7beb4d4', 'hex');
+        var expected = Buffer.from('e7beb4d4', 'hex');
         customnet[key].should.deep.equal(expected);
       }
     }

--- a/test/opcode.js
+++ b/test/opcode.js
@@ -57,7 +57,7 @@ describe('Opcode', function() {
 
   describe('#buffer', function() {
     it('should correctly input/output a buffer', function() {
-      var buf = new Buffer('a6', 'hex');
+      var buf = Buffer.from('a6', 'hex');
       Opcode.fromBuffer(buf).toBuffer().should.deep.equal(buf);
     });
   });

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -20,7 +20,7 @@ var invalidbase58 = require('./data/bitcoind/base58_keys_invalid.json');
 describe('PrivateKey', function() {
   var hex = '96c132224121b509b7d0a16245e957d9192609c5637c6228311287b1be21627a';
   var hex2 = '8080808080808080808080808080808080808080808080808080808080808080';
-  var buf = new Buffer(hex, 'hex');
+  var buf = Buffer.from(hex, 'hex');
   var wifTestnet = 'cSdkPxkAjA4HDr5VHgsebAPDEh9Gyub4HK8UJr2DFGGqKKy4K5sG';
   var wifTestnetUncompressed = '92jJzK4tbURm1C7udQXxeCBvXHoHJstDXRxAMouPG1k1XUaXdsu';
   var wifLivenet = 'XGLgPK8gbmzU7jcbw34Pj55AXV7SmG6carKuiwtu4WtvTjyTbpwX';
@@ -130,7 +130,7 @@ describe('PrivateKey', function() {
     it('should not be able to instantiate private key WIF is too long', function() {
       expect(function() {
         var buf = Base58Check.decode('XHWwKGqugqSRkcpuiWyDJXSHhjWGCidZ5HLwf9ScMLaEeDTRHepq');
-        var buf2 = Buffer.concat([buf, new Buffer(0x01)]);
+        var buf2 = Buffer.concat([buf, Buffer.alloc(0x01)]);
         return new PrivateKey(buf2);
       }).to.throw('Length of buffer must be 33 (uncompressed) or 34 (compressed');
     });
@@ -138,7 +138,7 @@ describe('PrivateKey', function() {
     it('should not be able to instantiate private key WIF because of unknown network byte', function() {
       expect(function() {
         var buf = Base58Check.decode('XHWwKGqugqSRkcpuiWyDJXSHhjWGCidZ5HLwf9ScMLaEeDTRHepq');
-        var buf2 = Buffer.concat([new Buffer('ff', 'hex'), buf.slice(1, 33)]);
+        var buf2 = Buffer.concat([Buffer.from('ff', 'hex'), buf.slice(1, 33)]);
         return new PrivateKey(buf2);
       }).to.throw('Invalid network');
     });
@@ -335,7 +335,7 @@ describe('PrivateKey', function() {
     });
 
     it('will output a 31 byte buffer', function() {
-      var bn = BN.fromBuffer(new Buffer('9b5a0e8fee1835e21170ce1431f9b6f19b487e67748ed70d8a4462bc031915', 'hex'));
+      var bn = BN.fromBuffer(Buffer.from('9b5a0e8fee1835e21170ce1431f9b6f19b487e67748ed70d8a4462bc031915', 'hex'));
       var privkey = new PrivateKey(bn);
       var buffer = privkey.toBufferNoPadding();
       buffer.length.should.equal(31);
@@ -343,7 +343,7 @@ describe('PrivateKey', function() {
 
     // TODO: enable for v1.0.0 when toBuffer is changed to always be 32 bytes long
     // it('will output a 32 byte buffer', function() {
-    //   var bn = BN.fromBuffer(new Buffer('9b5a0e8fee1835e21170ce1431f9b6f19b487e67748ed70d8a4462bc031915', 'hex'));
+    //   var bn = BN.fromBuffer(Buffer.from('9b5a0e8fee1835e21170ce1431f9b6f19b487e67748ed70d8a4462bc031915', 'hex'));
     //   var privkey = new PrivateKey(bn);
     //   var buffer = privkey.toBuffer();
     //   buffer.length.should.equal(32);
@@ -353,7 +353,7 @@ describe('PrivateKey', function() {
     // it('should return buffer with length equal 32', function() {
     //   var bn = BN.fromBuffer(buf.slice(0, 31));
     //   var privkey = new PrivateKey(bn, 'livenet');
-    //   var expected = Buffer.concat([ new Buffer([0]), buf.slice(0, 31) ]);
+    //   var expected = Buffer.concat([ Buffer.from([0]), buf.slice(0, 31) ]);
     //   privkey.toBuffer().toString('hex').should.equal(expected.toString('hex'));
     // });
   });
@@ -419,7 +419,7 @@ describe('PrivateKey', function() {
     it('should convert this known PrivateKey to known PublicKey', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(new Buffer(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
       var pubkey = privkey.toPublicKey();
       pubkey.toString().should.equal(pubhex);
     });
@@ -427,7 +427,7 @@ describe('PrivateKey', function() {
     it('should have a "publicKey" property', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(new Buffer(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
       privkey.publicKey.toString().should.equal(pubhex);
     });
 

--- a/test/publickey.js
+++ b/test/publickey.js
@@ -52,7 +52,7 @@ describe('PublicKey', function() {
     it('from a private key', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(new Buffer(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
       var pk = new PublicKey(privkey);
       pk.toString().should.equal(pubhex);
     });
@@ -112,7 +112,7 @@ describe('PublicKey', function() {
     });
 
     it('from a hex encoded DER buffer', function() {
-      var pk = new PublicKey(new Buffer('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341', 'hex'));
+      var pk = new PublicKey(Buffer.from('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341', 'hex'));
       should.exist(pk.point);
       pk.point.getX().toString(16).should.equal('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
     });
@@ -223,20 +223,20 @@ describe('PublicKey', function() {
   describe('#fromBuffer', function() {
 
     it('should parse this uncompressed public key', function() {
-      var pk = PublicKey.fromBuffer(new Buffer('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341', 'hex'));
+      var pk = PublicKey.fromBuffer(Buffer.from('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341', 'hex'));
       pk.point.getX().toString(16).should.equal('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
       pk.point.getY().toString(16).should.equal('7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341');
     });
 
     it('should parse this compressed public key', function() {
-      var pk = PublicKey.fromBuffer(new Buffer('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
+      var pk = PublicKey.fromBuffer(Buffer.from('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
       pk.point.getX().toString(16).should.equal('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
       pk.point.getY().toString(16).should.equal('7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341');
     });
 
     it('should throw an error on this invalid public key', function() {
       (function() {
-        PublicKey.fromBuffer(new Buffer('091ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
+        PublicKey.fromBuffer(Buffer.from('091ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
       }).should.throw();
     });
 
@@ -248,7 +248,7 @@ describe('PublicKey', function() {
 
     it('should throw error because buffer is the incorrect length', function() {
       (function() {
-        PublicKey.fromBuffer(new Buffer('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a34112', 'hex'));
+        PublicKey.fromBuffer(Buffer.from('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a34112', 'hex'));
       }).should.throw('Length of x and y must be 32 bytes');
     });
 
@@ -257,20 +257,20 @@ describe('PublicKey', function() {
   describe('#fromDER', function() {
 
     it('should parse this uncompressed public key', function() {
-      var pk = PublicKey.fromDER(new Buffer('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341', 'hex'));
+      var pk = PublicKey.fromDER(Buffer.from('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341', 'hex'));
       pk.point.getX().toString(16).should.equal('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
       pk.point.getY().toString(16).should.equal('7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341');
     });
 
     it('should parse this compressed public key', function() {
-      var pk = PublicKey.fromDER(new Buffer('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
+      var pk = PublicKey.fromDER(Buffer.from('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
       pk.point.getX().toString(16).should.equal('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
       pk.point.getY().toString(16).should.equal('7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341');
     });
 
     it('should throw an error on this invalid public key', function() {
       (function() {
-        PublicKey.fromDER(new Buffer('091ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
+        PublicKey.fromDER(Buffer.from('091ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
       }).should.throw();
     });
 
@@ -289,7 +289,7 @@ describe('PublicKey', function() {
   describe('#fromX', function() {
 
     it('should create this known public key', function() {
-      var x = BN.fromBuffer(new Buffer('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
+      var x = BN.fromBuffer(Buffer.from('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
       var pk = PublicKey.fromX(true, x);
       pk.point.getX().toString(16).should.equal('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
       pk.point.getY().toString(16).should.equal('7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341');
@@ -297,7 +297,7 @@ describe('PublicKey', function() {
 
 
     it('should error because odd was not included as a param', function() {
-      var x = BN.fromBuffer(new Buffer('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
+      var x = BN.fromBuffer(Buffer.from('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
       (function() {
         return PublicKey.fromX(null, x);
       }).should.throw('Must specify whether y is odd or not (true or false)');
@@ -308,13 +308,13 @@ describe('PublicKey', function() {
   describe('#toBuffer', function() {
 
     it('should return this compressed DER format', function() {
-      var x = BN.fromBuffer(new Buffer('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
+      var x = BN.fromBuffer(Buffer.from('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
       var pk = PublicKey.fromX(true, x);
       pk.toBuffer().toString('hex').should.equal('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
     });
 
     it('should return this uncompressed DER format', function() {
-      var x = BN.fromBuffer(new Buffer('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
+      var x = BN.fromBuffer(Buffer.from('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
       var pk = PublicKey.fromX(true, x);
       pk.toBuffer().toString('hex').should.equal('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
     });
@@ -324,7 +324,7 @@ describe('PublicKey', function() {
   describe('#toDER', function() {
 
     it('should return this compressed DER format', function() {
-      var x = BN.fromBuffer(new Buffer('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
+      var x = BN.fromBuffer(Buffer.from('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
       var pk = PublicKey.fromX(true, x);
       pk.toDER().toString('hex').should.equal('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
     });

--- a/test/script/interpreter.js
+++ b/test/script/interpreter.js
@@ -34,10 +34,10 @@ Script.fromBitcoindString = function(str) {
     var tbuf;
     if (token[0] === '0' && token[1] === 'x') {
       var hex = token.slice(2);
-      bw.write(new Buffer(hex, 'hex'));
+      bw.write(Buffer.from(hex, 'hex'));
     } else if (token[0] === '\'') {
       var tstr = token.slice(1, token.length - 1);
-      var cbuf = new Buffer(tstr);
+      var cbuf = Buffer.from(tstr);
       tbuf = Script().add(cbuf).toBuffer();
       bw.write(tbuf);
     } else if (typeof Opcode['OP_' + token] !== 'undefined') {
@@ -83,7 +83,7 @@ describe('Interpreter', function() {
       Interpreter.castToBool(new BN(0).toSM({
         endian: 'little'
       })).should.equal(false);
-      Interpreter.castToBool(new Buffer('0080', 'hex')).should.equal(false); //negative 0
+      Interpreter.castToBool(Buffer.from('0080', 'hex')).should.equal(false); //negative 0
       Interpreter.castToBool(new BN(1).toSM({
         endian: 'little'
       })).should.equal(true);
@@ -91,7 +91,7 @@ describe('Interpreter', function() {
         endian: 'little'
       })).should.equal(true);
 
-      var buf = new Buffer('00', 'hex');
+      var buf = Buffer.from('00', 'hex');
       var bool = BN.fromSM(buf, {
         endian: 'little'
       }).cmp(BN.Zero) !== 0;
@@ -202,7 +202,7 @@ describe('Interpreter', function() {
     var scriptPubkey = Script.fromBitcoindString(vector[1]);
     var flags = getFlags(vector[2]);
 
-    var hashbuf = new Buffer(32);
+    var hashbuf = Buffer.alloc(32);
     hashbuf.fill(0);
     var credtx = new Transaction();
     // Set version directly, since default version has been changed in DIP2, and this test suit

--- a/test/script/script.js
+++ b/test/script/script.js
@@ -24,7 +24,7 @@ describe('Script', function() {
   describe('#fromBuffer', function() {
 
     it('should parse this buffer containing an OP code', function() {
-      var buf = new Buffer(1);
+      var buf = Buffer.alloc(1);
       buf[0] = Opcode.OP_0;
       var script = Script.fromBuffer(buf);
       script.chunks.length.should.equal(1);
@@ -32,7 +32,7 @@ describe('Script', function() {
     });
 
     it('should parse this buffer containing another OP code', function() {
-      var buf = new Buffer(1);
+      var buf = Buffer.alloc(1);
       buf[0] = Opcode.OP_CHECKMULTISIG;
       var script = Script.fromBuffer(buf);
       script.chunks.length.should.equal(1);
@@ -40,14 +40,14 @@ describe('Script', function() {
     });
 
     it('should parse this buffer containing three bytes of data', function() {
-      var buf = new Buffer([3, 1, 2, 3]);
+      var buf = Buffer.from([3, 1, 2, 3]);
       var script = Script.fromBuffer(buf);
       script.chunks.length.should.equal(1);
       script.chunks[0].buf.toString('hex').should.equal('010203');
     });
 
     it('should parse this buffer containing OP_PUSHDATA1 and three bytes of data', function() {
-      var buf = new Buffer([0, 0, 1, 2, 3]);
+      var buf = Buffer.from([0, 0, 1, 2, 3]);
       buf[0] = Opcode.OP_PUSHDATA1;
       buf.writeUInt8(3, 1);
       var script = Script.fromBuffer(buf);
@@ -56,7 +56,7 @@ describe('Script', function() {
     });
 
     it('should parse this buffer containing OP_PUSHDATA2 and three bytes of data', function() {
-      var buf = new Buffer([0, 0, 0, 1, 2, 3]);
+      var buf = Buffer.from([0, 0, 0, 1, 2, 3]);
       buf[0] = Opcode.OP_PUSHDATA2;
       buf.writeUInt16LE(3, 1);
       var script = Script.fromBuffer(buf);
@@ -65,7 +65,7 @@ describe('Script', function() {
     });
 
     it('should parse this buffer containing OP_PUSHDATA4 and three bytes of data', function() {
-      var buf = new Buffer([0, 0, 0, 0, 0, 1, 2, 3]);
+      var buf = Buffer.from([0, 0, 0, 0, 0, 1, 2, 3]);
       buf[0] = Opcode.OP_PUSHDATA4;
       buf.writeUInt16LE(3, 1);
       var script = Script.fromBuffer(buf);
@@ -74,7 +74,7 @@ describe('Script', function() {
     });
 
     it('should parse this buffer an OP code, data, and another OP code', function() {
-      var buf = new Buffer([0, 0, 0, 0, 0, 0, 1, 2, 3, 0]);
+      var buf = Buffer.from([0, 0, 0, 0, 0, 0, 1, 2, 3, 0]);
       buf[0] = Opcode.OP_0;
       buf[1] = Opcode.OP_PUSHDATA4;
       buf.writeUInt16LE(3, 2);
@@ -91,7 +91,7 @@ describe('Script', function() {
   describe('#toBuffer', function() {
 
     it('should output this buffer containing an OP code', function() {
-      var buf = new Buffer(1);
+      var buf = Buffer.alloc(1);
       buf[0] = Opcode.OP_0;
       var script = Script.fromBuffer(buf);
       script.chunks.length.should.equal(1);
@@ -100,7 +100,7 @@ describe('Script', function() {
     });
 
     it('should output this buffer containing another OP code', function() {
-      var buf = new Buffer(1);
+      var buf = Buffer.alloc(1);
       buf[0] = Opcode.OP_CHECKMULTISIG;
       var script = Script.fromBuffer(buf);
       script.chunks.length.should.equal(1);
@@ -109,7 +109,7 @@ describe('Script', function() {
     });
 
     it('should output this buffer containing three bytes of data', function() {
-      var buf = new Buffer([3, 1, 2, 3]);
+      var buf = Buffer.from([3, 1, 2, 3]);
       var script = Script.fromBuffer(buf);
       script.chunks.length.should.equal(1);
       script.chunks[0].buf.toString('hex').should.equal('010203');
@@ -117,7 +117,7 @@ describe('Script', function() {
     });
 
     it('should output this buffer containing OP_PUSHDATA1 and three bytes of data', function() {
-      var buf = new Buffer([0, 0, 1, 2, 3]);
+      var buf = Buffer.from([0, 0, 1, 2, 3]);
       buf[0] = Opcode.OP_PUSHDATA1;
       buf.writeUInt8(3, 1);
       var script = Script.fromBuffer(buf);
@@ -127,7 +127,7 @@ describe('Script', function() {
     });
 
     it('should output this buffer containing OP_PUSHDATA2 and three bytes of data', function() {
-      var buf = new Buffer([0, 0, 0, 1, 2, 3]);
+      var buf = Buffer.from([0, 0, 0, 1, 2, 3]);
       buf[0] = Opcode.OP_PUSHDATA2;
       buf.writeUInt16LE(3, 1);
       var script = Script.fromBuffer(buf);
@@ -137,7 +137,7 @@ describe('Script', function() {
     });
 
     it('should output this buffer containing OP_PUSHDATA4 and three bytes of data', function() {
-      var buf = new Buffer([0, 0, 0, 0, 0, 1, 2, 3]);
+      var buf = Buffer.from([0, 0, 0, 0, 0, 1, 2, 3]);
       buf[0] = Opcode.OP_PUSHDATA4;
       buf.writeUInt16LE(3, 1);
       var script = Script.fromBuffer(buf);
@@ -147,7 +147,7 @@ describe('Script', function() {
     });
 
     it('should output this buffer an OP code, data, and another OP code', function() {
-      var buf = new Buffer([0, 0, 0, 0, 0, 0, 1, 2, 3, 0]);
+      var buf = Buffer.from([0, 0, 0, 0, 0, 0, 1, 2, 3, 0]);
       buf[0] = Opcode.OP_0;
       buf[1] = Opcode.OP_PUSHDATA4;
       buf.writeUInt16LE(3, 2);
@@ -194,7 +194,7 @@ describe('Script', function() {
     });
 
     it('should output this buffer an OP code, data, and another OP code', function() {
-      var buf = new Buffer([0, 0, 0, 0, 0, 0, 1, 2, 3, 0]);
+      var buf = Buffer.from([0, 0, 0, 0, 0, 0, 1, 2, 3, 0]);
       buf[0] = Opcode.OP_0;
       buf[1] = Opcode.OP_PUSHDATA4;
       buf.writeUInt16LE(3, 2);
@@ -216,7 +216,7 @@ describe('Script', function() {
 
   describe('toHex', function() {
     it('should return an hexa string "03010203" as expected from [3, 1, 2, 3]', function() {
-      var buf = new Buffer([3, 1, 2, 3]);
+      var buf = Buffer.from([3, 1, 2, 3]);
       var script = Script.fromBuffer(buf);
       script.toHex().should.equal('03010203');
     });
@@ -229,24 +229,24 @@ describe('Script', function() {
     });
 
     it('validates that this 40-byte OP_RETURN is standard', function() {
-      var buf = new Buffer(40);
+      var buf = Buffer.alloc(40);
       buf.fill(0);
       Script('OP_RETURN 40 0x' + buf.toString('hex')).isDataOut().should.equal(true);
     });
     it('validates that this 80-byte OP_RETURN is standard', function() {
-      var buf = new Buffer(80);
+      var buf = Buffer.alloc(80);
       buf.fill(0);
       Script('OP_RETURN OP_PUSHDATA1 80 0x' + buf.toString('hex')).isDataOut().should.equal(true);
     });
 
     it('validates that this 40-byte long OP_CHECKMULTISIG is not standard op_return', function() {
-      var buf = new Buffer(40);
+      var buf = Buffer.alloc(40);
       buf.fill(0);
       Script('OP_CHECKMULTISIG 40 0x' + buf.toString('hex')).isDataOut().should.equal(false);
     });
 
     it('validates that this 81-byte OP_RETURN is not a valid standard OP_RETURN', function() {
-      var buf = new Buffer(81);
+      var buf = Buffer.alloc(81);
       buf.fill(0);
       Script('OP_RETURN OP_PUSHDATA1 81 0x' + buf.toString('hex')).isDataOut().should.equal(false);
     });
@@ -256,7 +256,7 @@ describe('Script', function() {
     it('correctly identify scriptSig as a public key in', function() {
       // from txid: 5c85ed63469aa9971b5d01063dbb8bcdafd412b2f51a3d24abf2e310c028bbf8
       // and input index: 5
-      var scriptBuffer = new Buffer('483045022050eb59c79435c051f45003d9f82865c8e4df5699d7722e77113ef8cadbd92109022100d4ab233e070070eb8e0e62e3d2d2eb9474a5bf135c9eda32755acb0875a6c20601', 'hex');
+      var scriptBuffer = Buffer.from('483045022050eb59c79435c051f45003d9f82865c8e4df5699d7722e77113ef8cadbd92109022100d4ab233e070070eb8e0e62e3d2d2eb9474a5bf135c9eda32755acb0875a6c20601', 'hex');
       var script = bitcore.Script.fromBuffer(scriptBuffer);
       script.isPublicKeyIn().should.equal(true);
     });
@@ -565,16 +565,16 @@ describe('Script', function() {
     });
 
     it('should add these push data', function() {
-      var buf = new Buffer(1);
+      var buf = Buffer.alloc(1);
       buf.fill(0);
       Script().add(buf).toString().should.equal('1 0x00');
-      buf = new Buffer(255);
+      buf = Buffer.alloc(255);
       buf.fill(0);
       Script().add(buf).toString().should.equal('OP_PUSHDATA1 255 0x' + buf.toString('hex'));
-      buf = new Buffer(256);
+      buf = Buffer.alloc(256);
       buf.fill(0);
       Script().add(buf).toString().should.equal('OP_PUSHDATA2 256 0x' + buf.toString('hex'));
-      buf = new Buffer(Math.pow(2, 16));
+      buf = Buffer.alloc(Math.pow(2, 16));
       buf.fill(0);
       Script().add(buf).toString().should.equal('OP_PUSHDATA4 ' + Math.pow(2, 16) + ' 0x' + buf.toString('hex'));
     });
@@ -582,13 +582,13 @@ describe('Script', function() {
     it('should add both pushdata and non-pushdata chunks', function() {
       Script().add('OP_CHECKMULTISIG').toString().should.equal('OP_CHECKMULTISIG');
       Script().add(Opcode.map.OP_CHECKMULTISIG).toString().should.equal('OP_CHECKMULTISIG');
-      var buf = new Buffer(1);
+      var buf = Buffer.alloc(1);
       buf.fill(0);
       Script().add(buf).toString().should.equal('1 0x00');
     });
 
     it('should work for no data OP_RETURN', function() {
-      Script().add(Opcode.OP_RETURN).add(new Buffer('')).toString().should.equal('OP_RETURN');
+      Script().add(Opcode.OP_RETURN).add(Buffer.from('')).toString().should.equal('OP_RETURN');
     });
     it('works with objects', function() {
       Script().add({
@@ -704,14 +704,14 @@ describe('Script', function() {
       s.isDataOut().should.equal(true);
     });
     it('should create script from empty data', function() {
-      var data = new Buffer('');
+      var data = Buffer.from('');
       var s = Script.buildDataOut(data);
       should.exist(s);
       s.toString().should.equal('OP_RETURN');
       s.isDataOut().should.equal(true);
     });
     it('should create script from some data', function() {
-      var data = new Buffer('bacacafe0102030405', 'hex');
+      var data = Buffer.from('bacacafe0102030405', 'hex');
       var s = Script.buildDataOut(data);
       should.exist(s);
       s.toString().should.equal('OP_RETURN 9 0xbacacafe0102030405');
@@ -796,17 +796,17 @@ describe('Script', function() {
       Script().add(1000).checkMinimalPush(0).should.equal(true);
       Script().add(0xffffffff).checkMinimalPush(0).should.equal(true);
       Script().add(0xffffffffffffffff).checkMinimalPush(0).should.equal(true);
-      Script().add(new Buffer([0])).checkMinimalPush(0).should.equal(true);
+      Script().add(Buffer.from([0])).checkMinimalPush(0).should.equal(true);
 
-      var buf = new Buffer(75);
+      var buf = Buffer.alloc(75);
       buf.fill(1);
       Script().add(buf).checkMinimalPush(0).should.equal(true);
 
-      buf = new Buffer(76);
+      buf = Buffer.alloc(76);
       buf.fill(1);
       Script().add(buf).checkMinimalPush(0).should.equal(true);
 
-      buf = new Buffer(256);
+      buf = Buffer.alloc(256);
       buf.fill(1);
       Script().add(buf).checkMinimalPush(0).should.equal(true);
     });
@@ -817,11 +817,11 @@ describe('Script', function() {
     it('works with this testnet transaction', function() {
       // testnet block: 00000000a36400fc06440512354515964bc36ecb0020bd0b0fd48ae201965f54
       // txhash: e362e21ff1d2ef78379d401d89b42ce3e0ce3e245f74b1f4cb624a8baa5d53ad (output 0);
-      var script = Script.fromBuffer(new Buffer('6a', 'hex'));
+      var script = Script.fromBuffer(Buffer.from('6a', 'hex'));
       var dataout = script.isDataOut();
       dataout.should.equal(true);
       var data = script.getData();
-      data.should.deep.equal(new Buffer(0));
+      data.should.deep.equal(Buffer.alloc(0));
     });
     it('for a P2PKH address', function() {
       var address = Address.fromString('XxGJLCB7BBXAgA1AbgtNDMyVpQV9yXd7oB');
@@ -834,7 +834,7 @@ describe('Script', function() {
       expect(BufferUtil.equal(script.getData(), address.hashBuffer)).to.be.true;
     });
     it('for a standard opreturn output', function() {
-      expect(BufferUtil.equal(Script('OP_RETURN 1 0xFF').getData(), new Buffer([255]))).to.be.true;
+      expect(BufferUtil.equal(Script('OP_RETURN 1 0xFF').getData(), Buffer.from([255]))).to.be.true;
     });
     it('fails if content is not recognized', function() {
       expect(function() {
@@ -924,10 +924,10 @@ describe('Script', function() {
       Script('OP_TRUE OP_TRUE').equals(Script('OP_TRUE OP_FALSE')).should.equal(false);
     });
     it('returns false for different data', function() {
-      Script().add(new Buffer('a')).equals(Script('OP_TRUE')).should.equal(false);
+      Script().add(Buffer.from('a')).equals(Script('OP_TRUE')).should.equal(false);
     });
     it('returns false for different data', function() {
-      Script().add(new Buffer('a')).equals(Script().add(new Buffer('b'))).should.equal(false);
+      Script().add(Buffer.from('a')).equals(Script().add(Buffer.from('b'))).should.equal(false);
     });
   });
 

--- a/test/transaction/output.js
+++ b/test/transaction/output.js
@@ -148,7 +148,7 @@ describe('Output', function() {
   });
 
   it('#toObject roundtrip will handle an invalid (null) script', function() {
-    var invalidOutputScript = new Buffer('0100000000000000014c', 'hex');
+    var invalidOutputScript = Buffer.from('0100000000000000014c', 'hex');
     var br = new bitcore.encoding.BufferReader(invalidOutputScript);
     var output = Output.fromBufferReader(br);
     var output2 = new Output(output.toObject());
@@ -157,7 +157,7 @@ describe('Output', function() {
   });
 
   it('inspect will work with an invalid (null) script', function() {
-    var invalidOutputScript = new Buffer('0100000000000000014c', 'hex');
+    var invalidOutputScript = Buffer.from('0100000000000000014c', 'hex');
     var br = new bitcore.encoding.BufferReader(invalidOutputScript);
     var output = Output.fromBufferReader(br);
     output.inspect().should.equal('<Output (1 sats) 4c>');
@@ -177,7 +177,7 @@ describe('Output', function() {
   it('sets script to null if it is an InvalidBuffer', function() {
     var output = new Output({
       satoshis: 1000,
-      script: new Buffer('4c', 'hex')
+      script: Buffer.from('4c', 'hex')
     });
     should.equal(output.script, null);
   });

--- a/test/transaction/sighash.js
+++ b/test/transaction/sighash.js
@@ -3,8 +3,6 @@
 
 'use strict';
 
-var buffer = require('buffer');
-
 var chai = require('chai');
 var expect = chai.expect;
 var should = chai.should();
@@ -23,12 +21,12 @@ describe('sighash', function() {
       return;
     }
     it('test vector from bitcoind #' + i + ' (' + vector[4].substring(0, 16) + ')', function() {
-      var txbuf = new buffer.Buffer(vector[0], 'hex');
-      var scriptbuf = new buffer.Buffer(vector[1], 'hex');
+      var txbuf = Buffer.from(vector[0], 'hex');
+      var scriptbuf = Buffer.from(vector[1], 'hex');
       var subscript = Script(scriptbuf);
       var nin = vector[2];
       var nhashtype = vector[3];
-      var sighashbuf = new buffer.Buffer(vector[4], 'hex');
+      var sighashbuf = Buffer.from(vector[4], 'hex');
       var tx = new Transaction(txbuf);
 
       //make sure transacion to/from buffer is isomorphic

--- a/test/transaction/signature.js
+++ b/test/transaction/signature.js
@@ -107,7 +107,7 @@ describe('TransactionSignature', function() {
     it('can deserialize when signature is a buffer', function() {
       var signature = getSignatureFromTransaction();
       var serialized = signature.toObject();
-      serialized.signature = new Buffer(serialized.signature, 'hex');
+      serialized.signature = Buffer.from(serialized.signature, 'hex');
       expect(TransactionSignature.fromObject(serialized).toObject()).to.deep.equal(signature.toObject());
     });
 

--- a/test/util/buffer.js
+++ b/test/util/buffer.js
@@ -15,23 +15,23 @@ describe('buffer utils', function() {
 
   describe('equals', function() {
     it('recognizes these two equal buffers', function() {
-      var bufferA = new Buffer([1, 2, 3]);
-      var bufferB = new Buffer('010203', 'hex');
+      var bufferA = Buffer.from([1, 2, 3]);
+      var bufferB = Buffer.from('010203', 'hex');
       BufferUtil.equal(bufferA, bufferB).should.equal(true);
     });
     it('no false positive: returns false with two different buffers', function() {
-      var bufferA = new Buffer([1, 2, 3]);
-      var bufferB = new Buffer('010204', 'hex');
+      var bufferA = Buffer.from([1, 2, 3]);
+      var bufferB = Buffer.from('010204', 'hex');
       BufferUtil.equal(bufferA, bufferB).should.equal(false);
     });
     it('coverage: quickly realizes a difference in size and returns false', function() {
-      var bufferA = new Buffer([1, 2, 3]);
-      var bufferB = new Buffer([]);
+      var bufferA = Buffer.from([1, 2, 3]);
+      var bufferB = Buffer.from([]);
       BufferUtil.equal(bufferA, bufferB).should.equal(false);
     });
     it('"equals" is an an alias for "equal"', function() {
-      var bufferA = new Buffer([1, 2, 3]);
-      var bufferB = new Buffer([1, 2, 3]);
+      var bufferA = Buffer.from([1, 2, 3]);
+      var bufferB = Buffer.from([1, 2, 3]);
       BufferUtil.equal(bufferA, bufferB).should.equal(true);
       BufferUtil.equals(bufferA, bufferB).should.equal(true);
     });
@@ -43,11 +43,11 @@ describe('buffer utils', function() {
         BufferUtil.fill('something');
       }).to.throw(errors.InvalidArgumentType);
       expect(function() {
-        BufferUtil.fill(new Buffer([0, 0, 0]), 'invalid');
+        BufferUtil.fill(Buffer.from([0, 0, 0]), 'invalid');
       }).to.throw(errors.InvalidArgumentType);
     });
     it('works correctly for a small buffer', function() {
-      var buffer = BufferUtil.fill(new Buffer(10), 6);
+      var buffer = BufferUtil.fill(Buffer.alloc(10), 6);
       for (var i = 0; i < 10; i++) {
         buffer[i].should.equal(6);
       }
@@ -59,7 +59,7 @@ describe('buffer utils', function() {
       expect(BufferUtil.isBuffer(1)).to.equal(false);
     });
     it('has no false negative', function() {
-      expect(BufferUtil.isBuffer(new Buffer(0))).to.equal(true);
+      expect(BufferUtil.isBuffer(Buffer.alloc(0))).to.equal(true);
     });
   });
 
@@ -96,7 +96,7 @@ describe('buffer utils', function() {
     });
     it('does a round trip', function() {
       expect(BufferUtil.integerAsSingleByteBuffer(
-        BufferUtil.integerFromSingleByteBuffer(new Buffer([255]))
+        BufferUtil.integerFromSingleByteBuffer(Buffer.from([255]))
       )[0]).to.equal(255);
     });
   });
@@ -131,7 +131,7 @@ describe('buffer utils', function() {
 
   describe('buffer to hex', function() {
     it('returns an expected value in hexa', function() {
-      expect(BufferUtil.bufferToHex(new Buffer([255, 0, 128]))).to.equal('ff0080');
+      expect(BufferUtil.bufferToHex(Buffer.from([255, 0, 128]))).to.equal('ff0080');
     });
     it('checks the argument type', function() {
       expect(function() {
@@ -139,7 +139,7 @@ describe('buffer utils', function() {
       }).to.throw(errors.InvalidArgumentType);
     });
     it('round trips', function() {
-      var original = new Buffer([255, 0, 128]);
+      var original = Buffer.from([255, 0, 128]);
       var hexa = BufferUtil.bufferToHex(original);
       var back = BufferUtil.hexToBuffer(hexa);
       expect(BufferUtil.equal(original, back)).to.equal(true);
@@ -149,7 +149,7 @@ describe('buffer utils', function() {
   describe('reverse', function() {
     it('reverses a buffer', function() {
       // http://bit.ly/1J2Ai4x
-      var original = new Buffer([255, 0, 128]);
+      var original = Buffer.from([255, 0, 128]);
       var reversed = BufferUtil.reverse(original);
       original[0].should.equal(reversed[2]);
       original[1].should.equal(reversed[1]);


### PR DESCRIPTION
### Issue being fixed or implemented
- Fix deprecation warning from node.js about unsafe `Buffer` usage

### What was done
- Changed all `new Buffer(value)` to `Buffer.from(value)` for the case when `value` is a typed array, `Buffer.from(value, encoding)` for the case when `value` is a string, and `Buffer.alloc` for the case when `value` is a number 

### What has been tested
- All tests are passing.

### Notes
Small explanation why this is needed:
Node.js deprecated usage of `new Buffer(value)` for several reasons.
1. `new Buffer(number)` will create a `Buffer` that contains _arbitrary memory_, which means, that if not filled with zeros afterward, the buffer would contain random data from memory, which is a serious security risk;
2. Since `Buffer` constructor working with a lot of different argument types, and JS isn't a statically typed language, `var buffer = new Buffer(foo);` can lead to unexpected results, including reading arbitrary memory, if the wrong type has been assigned to `foo`

More on the issue: https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/#variant-1