### PR TITLE
add editorconfig to suggest proper lines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true


### PR DESCRIPTION
I'm sure I've harped on this enough, but want to make sure our files have
proper lines, and POSIX standard defines a line thusly:

> 3.206 Line
>
> A sequence of zero or more non- <newline> characters plus a terminating
> <newline> character.

ref:
http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206

Adding this editorconfig just hints to text editors that we would like to save
files with this final newline character instead of omitting it.