### PR TITLE
Feature/merkle block get transaction hashes

### DIFF
--- a/lib/block/PartialMerkleTree.js
+++ b/lib/block/PartialMerkleTree.js
@@ -34,7 +34,7 @@ function PartialMerkleTree(serialized) {
       );
 
       this.totalTransactions = serialized.transactionHashes.length;
-      this.merkleFlags = convertBitArrayToUInt8Array(tree.flags.reverse());
+      this.merkleFlags = convertBitArrayToUInt8Array(tree.flags, true);
       this.merkleHashes = tree.merkleHashes;
     } else {
       throw new Error('Invalid argument passed to PartialMerkleTree - expected hex string, object or buffer');

--- a/lib/block/merkleblock.js
+++ b/lib/block/merkleblock.js
@@ -180,12 +180,12 @@ MerkleBlock.prototype.validMerkleTree = function validMerkleTree() {
 /**
  * Traverse the tree in this MerkleBlock, validating it along the way
  * Modeled after Bitcoin Core merkleblock.cpp TraverseAndExtract()
- * @param {Number} - depth - Current height
- * @param {Number} - pos - Current position in the tree
- * @param {Object} - opts - Object with values that need to be mutated throughout the traversal
- * @param {Number} - opts.flagBitsUsed - Number of flag bits used, should start at 0
- * @param {Number} - opts.hashesUsed - Number of hashes used, should start at 0
- * @param {Array} - opts.txs - Will finish populated by transactions found during traversal
+ * @param {Number} depth - Current height
+ * @param {Number} pos - Current position in the tree
+ * @param {Object} [opts] - Object with values that need to be mutated throughout the traversal
+ * @param {Number} [opts.flagBitsUsed] - Number of flag bits used, should start at 0
+ * @param {Number} [opts.hashesUsed] - Number of hashes used, should start at 0
+ * @param {Array} [opts.txs] - Will finish populated by transactions found during traversal
  * @returns {Buffer|null} - Buffer containing the Merkle Hash for that height
  * @private
  */
@@ -223,7 +223,7 @@ MerkleBlock.prototype._traverseMerkleTree = function traverseMerkleTree(depth, p
 
 /** Calculates the width of a merkle tree at a given height.
  *  Modeled after Bitcoin Core merkleblock.h CalcTreeWidth()
- * @param {Number} - Height at which we want the tree width
+ * @param {Number} height Height at which we want the tree width
  * @returns {Number} - Width of the tree at a given height
  * @private
  */
@@ -245,7 +245,17 @@ MerkleBlock.prototype._calcTreeHeight = function calcTreeHeight() {
 };
 
 /**
- * @param {Transaction|String} - Transaction or Transaction ID Hash
+ * @return {string[]}
+ */
+MerkleBlock.prototype.getMatchedTransactionHashes = function getMatchedTransactionHashes() {
+  var txs = [];
+  var height = this._calcTreeHeight();
+  this._traverseMerkleTree(height, 0, { txs: txs });
+  return txs;
+};
+
+/**
+ * @param {Transaction|String} tx Transaction or Transaction ID Hash
  * @returns {Boolean} - return true/false if this MerkleBlock has the TX or not
  * @private
  */
@@ -260,9 +270,7 @@ MerkleBlock.prototype.hasTransaction = function hasTransaction(tx) {
     hash = BufferUtil.reverse(Buffer.from(tx.id, 'hex')).toString('hex');
   }
 
-  var txs = [];
-  var height = this._calcTreeHeight();
-  this._traverseMerkleTree(height, 0, { txs: txs });
+  var txs = this.getMatchedTransactionHashes();
   return txs.indexOf(hash) !== -1;
 };
 

--- a/lib/util/bitarray.js
+++ b/lib/util/bitarray.js
@@ -10,37 +10,61 @@ function isBitString(bitString) {
   return binaryRegex.test(bitString);
 }
 
+function toBitString(bitArray) {
+  if (!Array.isArray(bitArray)) {
+    throw new TypeError("Argument is not a bit array");
+  }
+  return bitArray.map(function(bool) {
+    return Number(bool);
+  }).join('');
+}
+
 /**
  * Converts boolean array to uint8 array, i.e:
  * [true, true, true, true, true, true, true, true] will be converted to [255]
  * @param {boolean[]|number[]} bitArray
+ * @param {boolean} [reverseBits]
  * @return {number[]}
  */
-function convertBitArrayToUInt8Array(bitArray) {
-  if (!Array.isArray(bitArray)) {
-    throw new TypeError("Argument is not a bit array");
-  }
-  var bitString = bitArray.map(function(bool) {
-    return Number(bool);
-  }).join('');
-  return bitStringToUInt8Array(bitString);
+function convertBitArrayToUInt8Array(bitArray, reverseBits) {
+  var bitString = toBitString(bitArray);
+  return bitStringToUInt8Array(bitString, reverseBits);
 }
 
 /**
  * Converts a bit string, i.e. '1000101010101010100' to an array with 8 bit unsigned integers
  * @param {string} bitString
+ * @param {boolean} reverseBits
  * @return {number[]}
  */
-function bitStringToUInt8Array(bitString) {
+function bitStringToUInt8Array(bitString, reverseBits) {
   if (!isBitString(bitString)) {
     throw new TypeError("Argument is not a bit array");
   }
-  var bytes = bitString.match(/.{1,8}/g);
-  return bytes.map(function (byte) {
-    return parseInt(byte, 2);
+  var byteStrings = bitString.match(/.{1,8}/g);
+  return byteStrings.map(function (byteString) {
+    if (reverseBits) {
+      byteString = byteString.split("").reverse().join("");
+    }
+    return parseInt(byteString, 2);
   });
 }
 
+function uint8ArrayToBitString(uin8arr) {
+  return uin8arr
+    .map(function(num) {
+      return num.toString(2);
+    })
+    .reduce(function (acc, val) {
+      // Add leading zeros if needed
+      if (val.length < 8) {
+        val = '0'.repeat(8 - val.length) + val;
+      }
+      return acc + val
+    }, '');
+}
+
 module.exports = {
-  convertBitArrayToUInt8Array: convertBitArrayToUInt8Array
+  convertBitArrayToUInt8Array: convertBitArrayToUInt8Array,
+  uint8ArrayToBitString: uint8ArrayToBitString
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4785,7 +4785,7 @@
         },
         "execa": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
@@ -4811,7 +4811,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -4826,7 +4826,7 @@
         },
         "get-stream": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
@@ -4835,13 +4835,13 @@
         },
         "invert-kv": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
         "lcid": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
@@ -4850,7 +4850,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
@@ -4881,7 +4881,7 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
           "dev": true,
           "requires": {
@@ -4896,7 +4896,7 @@
         },
         "os-locale": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
@@ -4916,7 +4916,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
@@ -4937,7 +4937,7 @@
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
@@ -4946,7 +4946,7 @@
         },
         "pump": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "description": "A pure and powerful JavaScript Dash library.",
   "author": "Dash Core Group, Inc. <dev@dash.org>",
   "main": "index.js",

--- a/test/block/PartialMerkleTree.js
+++ b/test/block/PartialMerkleTree.js
@@ -27,7 +27,31 @@ describe('PartialMerkleTree', function () {
           ],
           merkleFlags: [15]
         }
-      }
+      },
+      // Case 2
+      {
+        transactionHashes: [
+          '7622a8766251223eecf7820bbb116f4889c48cc9942d08f4687033e8f59431ab',
+          '94a469e14ef925159b1154081ace607c7b0f4d342d3e62c5fef0d3ce56dbe7d4',
+          'a13000f587c512c01bc53f844966b5c72622098031431eb919e2b82507215391',
+          '3f3517ee8fa95621fe8abdd81c1e0dfb50e21dd4c5a3c01eee2c47cf664821b6',
+          '7262476912a96b9a6226cfa3a8f231ba3e2b1f75c396e88367e532c79c43c95b'
+        ].map(function (hash) {
+          return Buffer.from(hash, 'hex');
+        }),
+        matches: [true, false, true, false, true],
+        expectedPartialTree: {
+          totalTransactions: 5,
+          merkleHashes: [
+            '7622a8766251223eecf7820bbb116f4889c48cc9942d08f4687033e8f59431ab',
+            '94a469e14ef925159b1154081ace607c7b0f4d342d3e62c5fef0d3ce56dbe7d4',
+            'a13000f587c512c01bc53f844966b5c72622098031431eb919e2b82507215391',
+            '3f3517ee8fa95621fe8abdd81c1e0dfb50e21dd4c5a3c01eee2c47cf664821b6',
+            '7262476912a96b9a6226cfa3a8f231ba3e2b1f75c396e88367e532c79c43c95b'
+          ],
+          merkleFlags: [111,7]
+        }
+      },
     ];
 
     testCases.forEach(function (testCase, index) {
@@ -44,3 +68,5 @@ describe('PartialMerkleTree', function () {
     });
   });
 });
+
+

--- a/test/block/merkleblock.js
+++ b/test/block/merkleblock.js
@@ -3,7 +3,10 @@
 
 'use strict';
 
-var should = require('chai').should();
+var chai = require('chai');
+
+var should = chai.should();
+var expect = chai.expect;
 
 var bitcore = require('../..');
 var MerkleBlock = bitcore.MerkleBlock;
@@ -202,6 +205,54 @@ describe('MerkleBlock', function() {
     });
 
   });
+
+  describe('getMatchedTransactionHashes', function () {
+    var getMatchedTransactionsTestCases = [
+      {
+        filterMatches: [true, false, false, false, false],
+        expectedMatchedTransactionHashes: [
+          '7622a8766251223eecf7820bbb116f4889c48cc9942d08f4687033e8f59431ab',
+        ]
+      },
+      {
+        filterMatches: [true, false, true, false, false],
+        expectedMatchedTransactionHashes: [
+          '7622a8766251223eecf7820bbb116f4889c48cc9942d08f4687033e8f59431ab',
+          'a13000f587c512c01bc53f844966b5c72622098031431eb919e2b82507215391'
+        ]
+      },
+      {
+        filterMatches: [false, false, false, false, true],
+        expectedMatchedTransactionHashes: [
+          '7262476912a96b9a6226cfa3a8f231ba3e2b1f75c396e88367e532c79c43c95b'
+        ]
+      }
+    ];
+    getMatchedTransactionsTestCases.forEach(function(testCase, index) {
+      it('should return an array of matched transactions, case #' + index, function () {
+        var transactionHashHexes = [
+          '7622a8766251223eecf7820bbb116f4889c48cc9942d08f4687033e8f59431ab',
+          '94a469e14ef925159b1154081ace607c7b0f4d342d3e62c5fef0d3ce56dbe7d4',
+          'a13000f587c512c01bc53f844966b5c72622098031431eb919e2b82507215391',
+          '3f3517ee8fa95621fe8abdd81c1e0dfb50e21dd4c5a3c01eee2c47cf664821b6',
+          '7262476912a96b9a6226cfa3a8f231ba3e2b1f75c396e88367e532c79c43c95b'
+        ];
+        var transactionHashes = transactionHashHexes.map(function (hash) {
+          return Buffer.from(hash, 'hex');
+        });
+
+        var merkleBlock = MerkleBlock.build(
+          data.JSON[1].header,
+          transactionHashes,
+          testCase.filterMatches
+        );
+
+        var actualMatchedTransactionHashes = merkleBlock.getMatchedTransactionHashes();
+        expect(actualMatchedTransactionHashes.length).to.be.equal(testCase.expectedMatchedTransactionHashes.length);
+        expect(actualMatchedTransactionHashes).to.be.deep.equal(testCase.expectedMatchedTransactionHashes);
+      });
+    });
+  })
 
 });
 


### PR DESCRIPTION
### Issue being fixed or implemented
- Added `getTransactionHashes` method to `MerkleBlock`

### What was done
- Added `getTransactionHashes` method to `MerkleBlock`
- Added tests for `getTransactionHashes`
- Added options to reverse bits in flags when converting bit array to UInt8 array
- Fixed bug in `PartialMerkleTree`
- Added more test cases for `PartialMerkleTree`