### PR TITLE
fix: inconsistencies between DashCore RPC quorum output

### DIFF
--- a/lib/deterministicmnlist/QuorumEntry.js
+++ b/lib/deterministicmnlist/QuorumEntry.js
@@ -11,9 +11,10 @@ var Hash = require('../crypto/hash');
 var constants = require('../constants');
 var utils = require('../util/js');
 
-var isSha256 = utils.isSha256HexString;
-var isHexStringOfSize = utils.isHexStringOfSize;
 var isHexString = utils.isHexaString;
+var isHexStringOfSize = utils.isHexStringOfSize;
+var isUnsignedInteger = utils.isUnsignedInteger;
+var isSha256 = utils.isSha256HexString;
 
 var SHA256_HASH_SIZE = constants.SHA256_HASH_SIZE;
 var BLS_PUBLIC_KEY_SIZE = constants.BLS_PUBLIC_KEY_SIZE;
@@ -213,20 +214,14 @@ QuorumEntry.prototype.validate = function validate() {
   $.checkArgument(utils.isUnsignedInteger(this.version), 'Expect version to be an unsigned integer');
   $.checkArgument(utils.isUnsignedInteger(this.llmqType), 'Expect llmqType to be an unsigned integer');
   $.checkArgument(isSha256(this.quorumHash), 'Expected quorumHash to be a sha256 hex string');
-  if (this.signers) {
-    $.checkArgument(utils.isHexaString(this.signers), 'Expect signers to be a hex string');
-  }
-  if (this.validMembers) {
-    $.checkArgument(utils.isHexaString(this.validMembers), 'Expect validMembers to be a hex string');
-  }
+  $.checkArgument(isUnsignedInteger(this.signersCount), 'Expect signersCount to be an unsigned integer');
+  $.checkArgument(isUnsignedInteger(this.validMembersCount), 'Expect validMembersCount to be an unsigned integer');
   $.checkArgument(isHexStringOfSize(this.quorumPublicKey, BLS_PUBLIC_KEY_SIZE * 2), 'Expected quorumPublicKey to be a bls pubkey');
-  if (this.quorumVvecHash) {
+  if (!this.isOutdatedRPC) {
+    $.checkArgument(utils.isHexaString(this.signers), 'Expect signers to be a hex string');
+    $.checkArgument(utils.isHexaString(this.validMembers), 'Expect validMembers to be a hex string');
     $.checkArgument(isHexStringOfSize(this.quorumVvecHash, SHA256_HASH_SIZE * 2), `Expected quorumVvecHash to be a hex string of size ${SHA256_HASH_SIZE}`);
-  }
-  if (this.quorumSig) {
     $.checkArgument(isHexStringOfSize(this.quorumSig, BLS_SIGNATURE_SIZE * 2), 'Expected quorumSig to be a bls signature');
-  }
-  if (this.membersSig) {
     $.checkArgument(isHexStringOfSize(this.membersSig, BLS_SIGNATURE_SIZE * 2), 'Expected membersSig to be a bls signature');
   }
 };

--- a/lib/deterministicmnlist/QuorumEntry.js
+++ b/lib/deterministicmnlist/QuorumEntry.js
@@ -244,7 +244,6 @@ QuorumEntry.prototype.toObject = function toObject() {
     quorumVvecHash: this.quorumVvecHash,
     quorumSig: this.quorumSig,
     membersSig: this.membersSig,
-    isOutdatedRPC: this.isOutdatedRPC,
   };
 };
 

--- a/lib/deterministicmnlist/QuorumEntry.js
+++ b/lib/deterministicmnlist/QuorumEntry.js
@@ -113,13 +113,23 @@ QuorumEntry.prototype.toBuffer = function toBuffer() {
   bufferWriter.writeUInt8(this.llmqType);
   bufferWriter.write(Buffer.from(this.quorumHash, 'hex').reverse());
   bufferWriter.writeVarintNum(this.signersCount);
-  bufferWriter.write(Buffer.from(this.signers, 'hex'));
+  if (this.signers) {
+    bufferWriter.write(Buffer.from(this.signers, 'hex'));
+  }
   bufferWriter.writeVarintNum(this.validMembersCount);
-  bufferWriter.write(Buffer.from(this.validMembers, 'hex'));
+  if (this.validMembers) {
+    bufferWriter.write(Buffer.from(this.validMembers, 'hex'));
+  }
   bufferWriter.write(Buffer.from(this.quorumPublicKey, 'hex'));
-  bufferWriter.write(Buffer.from(this.quorumVvecHash, 'hex').reverse());
-  bufferWriter.write(Buffer.from(this.quorumSig, 'hex'));
-  bufferWriter.write(Buffer.from(this.membersSig, 'hex'));
+  if (this.quorumVvecHash) {
+    bufferWriter.write(Buffer.from(this.quorumVvecHash, 'hex').reverse());
+  }
+  if (this.quorumSig) {
+    bufferWriter.write(Buffer.from(this.quorumSig, 'hex'));
+  }
+  if (this.membersSig) {
+    bufferWriter.write(Buffer.from(this.membersSig, 'hex'));
+  }
 
   return bufferWriter.toBuffer();
 };

--- a/lib/deterministicmnlist/QuorumEntry.js
+++ b/lib/deterministicmnlist/QuorumEntry.js
@@ -76,6 +76,18 @@ function QuorumEntry(arg) {
 QuorumEntry.fromBuffer = function fromBuffer(buffer) {
   var bufferReader = new BufferReader(buffer);
   var SMLQuorumEntry = new QuorumEntry();
+  if (buffer.length < 100) {
+    SMLQuorumEntry.isOutdatedRPC = true;
+    SMLQuorumEntry.version = bufferReader.readUInt16LE();
+    SMLQuorumEntry.llmqType = bufferReader.readUInt8();
+    SMLQuorumEntry.quorumHash = bufferReader.read(constants.SHA256_HASH_SIZE).reverse().toString('hex');
+    SMLQuorumEntry.signersCount = bufferReader.readVarintNum();
+    SMLQuorumEntry.validMembersCount = bufferReader.readVarintNum();
+    SMLQuorumEntry.quorumPublicKey = bufferReader.read(BLS_PUBLIC_KEY_SIZE).toString('hex');
+
+    return SMLQuorumEntry;
+  }
+  SMLQuorumEntry.isOutdatedRPC = false;
   SMLQuorumEntry.version = bufferReader.readUInt16LE();
   SMLQuorumEntry.llmqType = bufferReader.readUInt8();
   SMLQuorumEntry.quorumHash = bufferReader.read(constants.SHA256_HASH_SIZE).reverse().toString('hex');
@@ -113,23 +125,20 @@ QuorumEntry.prototype.toBuffer = function toBuffer() {
   bufferWriter.writeUInt8(this.llmqType);
   bufferWriter.write(Buffer.from(this.quorumHash, 'hex').reverse());
   bufferWriter.writeVarintNum(this.signersCount);
-  if (this.signers) {
-    bufferWriter.write(Buffer.from(this.signers, 'hex'));
+  if (this.isOutdatedRPC) {
+    bufferWriter.writeVarintNum(this.validMembersCount);
+    bufferWriter.write(Buffer.from(this.quorumPublicKey, 'hex'));
+
+    return bufferWriter.toBuffer();
   }
+
+  bufferWriter.write(Buffer.from(this.signers, 'hex'));
   bufferWriter.writeVarintNum(this.validMembersCount);
-  if (this.validMembers) {
-    bufferWriter.write(Buffer.from(this.validMembers, 'hex'));
-  }
+  bufferWriter.write(Buffer.from(this.validMembers, 'hex'));
   bufferWriter.write(Buffer.from(this.quorumPublicKey, 'hex'));
-  if (this.quorumVvecHash) {
-    bufferWriter.write(Buffer.from(this.quorumVvecHash, 'hex').reverse());
-  }
-  if (this.quorumSig) {
-    bufferWriter.write(Buffer.from(this.quorumSig, 'hex'));
-  }
-  if (this.membersSig) {
-    bufferWriter.write(Buffer.from(this.membersSig, 'hex'));
-  }
+  bufferWriter.write(Buffer.from(this.quorumVvecHash, 'hex').reverse());
+  bufferWriter.write(Buffer.from(this.quorumSig, 'hex'));
+  bufferWriter.write(Buffer.from(this.membersSig, 'hex'));
 
   return bufferWriter.toBuffer();
 };
@@ -181,6 +190,7 @@ QuorumEntry.prototype.getCommitmentHash = function getCommitmentBuffer() {
  */
 QuorumEntry.fromObject = function fromObject(obj) {
   var SMLQuorumEntry = new QuorumEntry();
+  SMLQuorumEntry.isOutdatedRPC = false;
   SMLQuorumEntry.version = obj.version;
   SMLQuorumEntry.llmqType = obj.llmqType;
   SMLQuorumEntry.quorumHash = obj.quorumHash;
@@ -192,7 +202,9 @@ QuorumEntry.fromObject = function fromObject(obj) {
   SMLQuorumEntry.quorumVvecHash = obj.quorumVvecHash;
   SMLQuorumEntry.quorumSig = obj.quorumSig;
   SMLQuorumEntry.membersSig = obj.membersSig;
-
+  if (SMLQuorumEntry.signers === undefined) {
+    SMLQuorumEntry.isOutdatedRPC = true;
+  }
   SMLQuorumEntry.validate();
   return SMLQuorumEntry;
 };
@@ -232,6 +244,7 @@ QuorumEntry.prototype.toObject = function toObject() {
     quorumVvecHash: this.quorumVvecHash,
     quorumSig: this.quorumSig,
     membersSig: this.membersSig,
+    isOutdatedRPC: this.isOutdatedRPC,
   };
 };
 

--- a/lib/deterministicmnlist/SimplifiedMNList.js
+++ b/lib/deterministicmnlist/SimplifiedMNList.js
@@ -84,7 +84,7 @@ SimplifiedMNList.prototype.applyDiff = function applyDiff(simplifiedMNListDiff) 
     this.addAndMaybeRemoveQuorums(diff.newQuorums);
     this.lastDiffMerkleRootQuorums = diff.merkleRootQuorums || constants.NULL_HASH;
 
-    // we cannot verify the quorum merkle root from DashCore vers. < 0.16
+    // we cannot verify the quorum merkle root for DashCore vers. < 0.16
     if (this.quorumList[0].isOutdatedRPC) {
       this.merkleRootQuorums = diff.merkleRootQuorums;
       return

--- a/lib/deterministicmnlist/SimplifiedMNList.js
+++ b/lib/deterministicmnlist/SimplifiedMNList.js
@@ -121,7 +121,7 @@ SimplifiedMNList.prototype.addOrUpdateMNs = function addMNs(mnListEntries) {
  * if list has reached maximum entries for llmqType
  * @param {QuorumEntry[]} quorumEntries
  */
-SimplifiedMNList.prototype.addAndMaybeRemoveQuorums = function addOrUpdateQuorums(quorumEntries) {
+SimplifiedMNList.prototype.addAndMaybeRemoveQuorums = function addAndMaybeRemoveQuorums(quorumEntries) {
 
   var llmqTypeArray = [...this.getLLMQTypes()];
 

--- a/lib/deterministicmnlist/SimplifiedMNList.js
+++ b/lib/deterministicmnlist/SimplifiedMNList.js
@@ -74,23 +74,27 @@ SimplifiedMNList.prototype.applyDiff = function applyDiff(simplifiedMNListDiff) 
 
   this.cbTx = new Transaction(diff.cbTx);
   this.cbTxMerkleTree = diff.cbTxMerkleTree.copy();
-
+  this.validMNs = this.mnList.filter(function (smlEntry) {
+    return smlEntry.isValid;
+  });
   this.quorumsActive = this.cbTx.version >= 2;
 
   if (this.quorumsActive) {
     this.deleteQuorums(diff.deletedQuorums);
     this.addAndMaybeRemoveQuorums(diff.newQuorums);
     this.lastDiffMerkleRootQuorums = diff.merkleRootQuorums || constants.NULL_HASH;
-    this.merkleRootQuorums = this.calculateMerkleRootQuorums();
 
+    // we cannot verify the quorum merkle root from DashCore vers. < 0.16
+    if (this.quorumList[0].isOutdatedRPC) {
+      this.merkleRootQuorums = diff.merkleRootQuorums;
+      return
+    }
+
+    this.merkleRootQuorums = this.calculateMerkleRootQuorums();
     if (this.lastDiffMerkleRootQuorums !== this.merkleRootQuorums) {
       throw new Error("Quorum merkle root from the diff doesn't match calculated merkle root after diff is applied");
     }
   }
-
-  this.validMNs = this.mnList.filter(function (smlEntry) {
-    return smlEntry.isValid;
-  });
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "description": "A pure and powerful JavaScript Dash library.",
   "author": "Dash Core Group, Inc. <dev@dash.org>",
   "main": "index.js",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixed some bugs due to inconsistencies between DashCore 0.15 and 0.16 RPC output

## What was done?
<!--- Describe your changes in detail -->
Recognize 0.15 quorum buffer
Don't calculate quorum root for 0.15 nodes because it's impossible

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added 0.15 fixtures to test against
Removed them once it was working

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
