### PR TITLE
fix: SimplifiedMNListDiff doesn't accept network name as a string

### DIFF
--- a/lib/deterministicmnlist/SimplifiedMNListDiff.js
+++ b/lib/deterministicmnlist/SimplifiedMNListDiff.js
@@ -13,6 +13,7 @@ var QuorumEntry = require('./QuorumEntry');
 var PartialMerkleTree = require('../block/PartialMerkleTree');
 var Transaction = require('../transaction');
 var constants = require('../constants');
+var Networks = require('../networks');
 
 /**
  * @param {Buffer|Object|string} [arg] - A Buffer, JSON string, or Object representing a MnListDiff
@@ -31,6 +32,8 @@ var constants = require('../constants');
  */
 function SimplifiedMNListDiff(arg, network) {
   if (arg) {
+    network = Networks.get(network);
+
     if (arg instanceof SimplifiedMNListDiff) {
       return arg.copy();
     } else if (BufferUtil.isBuffer(arg)) {
@@ -153,6 +156,8 @@ SimplifiedMNListDiff.prototype.toBuffer = function toBuffer() {
  */
 SimplifiedMNListDiff.fromObject = function fromObject(obj, network) {
   var simplifiedMNListDiff = new SimplifiedMNListDiff();
+
+  network = Networks.get(network);
 
   simplifiedMNListDiff.baseBlockHash = obj.baseBlockHash;
   simplifiedMNListDiff.blockHash = obj.blockHash;

--- a/lib/deterministicmnlist/SimplifiedMNListEntry.js
+++ b/lib/deterministicmnlist/SimplifiedMNListEntry.js
@@ -12,6 +12,7 @@ var constants = require('../constants');
 var utils = require('../util/js');
 var ipUtils = require('../util/ip');
 var Address = require('../address');
+var Networks = require('../networks');
 
 var isSha256 = utils.isSha256HexString;
 var isHexStringOfSize = utils.isHexStringOfSize;
@@ -47,6 +48,8 @@ var BLS_PUBLIC_KEY_SIZE = constants.BLS_PUBLIC_KEY_SIZE;
  */
 function SimplifiedMNListEntry(arg, network) {
   if (arg) {
+    network = Networks.get(network);
+
     if (arg instanceof SimplifiedMNListEntry) {
       return arg.copy();
     } else if (BufferUtil.isBuffer(arg)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.18.9",
+  "version": "0.18.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8138,6 +8138,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -8211,6 +8212,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -8220,6 +8222,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.18.9",
+  "version": "0.18.10",
   "description": "A pure and powerful JavaScript Dash library.",
   "author": "Dash Core Group, Inc. <dev@dash.org>",
   "main": "index.js",

--- a/test/deterministicmnlist/SimplifiedMNListDiff.js
+++ b/test/deterministicmnlist/SimplifiedMNListDiff.js
@@ -71,6 +71,10 @@ describe('SimplifiedMNListDiff', function () {
       var diff = SimplifiedMNListDiff.fromObject(mnListDiffJSON);
       expect(diff.toObject()).to.be.deep.equal(mnListDiffJSON);
     });
+    it('Should be able to create an instance from object with specified network', function () {
+      var diff = SimplifiedMNListDiff.fromObject(mnListDiffJSON, 'testnet');
+      expect(diff.toObject()).to.be.deep.equal(mnListDiffJSON);
+    });
   });
   describe('toObject', function () {
     it('Should return an object with serialized diff data', function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`SimplifiedMNListDiff` doesn't accept network name as a string

## What was done?
<!--- Describe your changes in detail -->
Passed `network` to `Networks.get`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
