### PR TITLE
fix: `SimplifiedMNListDiff` do not pass network to `SimplifiedMNList`

### DIFF
--- a/lib/deterministicmnlist/SimplifiedMNList.js
+++ b/lib/deterministicmnlist/SimplifiedMNList.js
@@ -272,6 +272,11 @@ SimplifiedMNList.prototype.getValidMasternodesList = function getValidMasternode
  */
 SimplifiedMNList.prototype.getLLMQTypes = function getLLMQTypes() {
   var llmqTypes = [];
+
+  if (!this.network) {
+    throw new Error('Network is not set');
+  }
+
   switch (this.network.name) {
     case Networks.livenet.name:
       llmqTypes = [constants.LLMQ_TYPES.LLMQ_TYPE_50_60,

--- a/lib/deterministicmnlist/SimplifiedMNListDiff.js
+++ b/lib/deterministicmnlist/SimplifiedMNListDiff.js
@@ -151,7 +151,7 @@ SimplifiedMNListDiff.prototype.toBuffer = function toBuffer() {
 /**
  * Creates MNListDiff from object
  * @param obj
- * @param {string} [network]
+ * @param {string|Network} [network]
  * @return {SimplifiedMNListDiff}
  */
 SimplifiedMNListDiff.fromObject = function fromObject(obj, network) {
@@ -180,8 +180,15 @@ SimplifiedMNListDiff.fromObject = function fromObject(obj, network) {
   if (obj.merkleRootQuorums) {
     simplifiedMNListDiff.merkleRootQuorums = obj.merkleRootQuorums;
   }
-  if (simplifiedMNListDiff.mnList.length >= 1) {
+
+  if (simplifiedMNListDiff.mnList.length > 0) {
+    if (network && simplifiedMNListDiff.mnList[0].network.name !== network.name) {
+      throw new Error('votingAddress network is not equal to ' + network.name);
+    }
+
     simplifiedMNListDiff.network = simplifiedMNListDiff.mnList[0].network;
+  } else {
+    simplifiedMNListDiff.network = network;
   }
 
   return simplifiedMNListDiff;

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -47,7 +47,14 @@ function get(arg, keys) {
     }
     return undefined;
   }
-  return networkMaps[arg];
+
+  var network = networkMaps[arg];
+
+  if (network && network === testnet && (arg === 'local' || arg === 'regtest')) {
+    enableRegtest();
+  }
+
+  return network;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.18.10",
+  "version": "0.18.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.18.10",
+  "version": "0.18.11",
   "description": "A pure and powerful JavaScript Dash library.",
   "author": "Dash Core Group, Inc. <dev@dash.org>",
   "main": "index.js",

--- a/test/networks.js
+++ b/test/networks.js
@@ -36,8 +36,24 @@ describe('Networks', function() {
   });
 
   it('will get network based on string "regtest" value', function() {
+    networks.disableRegtest();
     var network = networks.get('regtest');
     network.should.equal(networks.testnet);
+    network.regtestEnabled.should.be.true;
+  });
+
+  it('will get network based on string "local" value', function() {
+    networks.disableRegtest();
+    var network = networks.get('local');
+    network.should.equal(networks.testnet);
+    network.regtestEnabled.should.be.true;
+  });
+
+  it('will get network based on string "evonet" value', function() {
+    networks.disableRegtest();
+    var network = networks.get('evonet');
+    network.should.equal(networks.testnet);
+    network.regtestEnabled.should.be.false;
   });
 
   it('should be able to define a custom Network', function() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`SimplifiedMNListDiff` do not pass network to `SimplifiedMNList`

## What was done?
<!--- Describe your changes in detail -->
- Pass network to SimplifiedMNList
- Enable regtest mode for 'local' and 'regtest' networks

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
