### PR TITLE
perf: return pregenerated SML if height is tip height

### DIFF
--- a/lib/deterministicmnlist/SimplifiedMNListStore.js
+++ b/lib/deterministicmnlist/SimplifiedMNListStore.js
@@ -113,9 +113,17 @@ SimplifiedMNListStore.prototype.getSMLDiffbyHeightRange = function getSMLDiffbyH
  * @returns {SimplifiedMNList}
  */
 SimplifiedMNListStore.prototype.getSMLbyHeight = function getSMLbyHeight(height) {
-  const diffs = (this.baseHeight === height)
-    ? [] : this.getSMLDiffbyHeightRange(this.baseHeight, height);
-  if (diffs.length === 0 && this.baseHeight !== height) {
+  if (height === this.baseHeight) {
+    return this.baseSimplifiedMNList;
+  }
+
+  if (height === this.getTipHeight()) {
+    return this.getCurrentSML();
+  }
+
+  const diffs = this.getSMLDiffbyHeightRange(this.baseHeight, height);
+
+  if (diffs.length === 0) {
     throw new Error('unable to construct SML at this height');
   }
   return this.createListFromBaseAndDiffs(diffs);
@@ -136,13 +144,13 @@ SimplifiedMNListStore.prototype.getCurrentSML = function getCurrentSML() {
  * @returns {SimplifiedMNList}
  */
 SimplifiedMNListStore.prototype.createListFromBaseAndDiffs = function createListFromBaseAndDiffs(diffs) {
-  const currentSML = new SimplifiedMNList(
+  const createdList = new SimplifiedMNList(
     this.baseSimplifiedMNList.toSimplifiedMNListDiff(), this.network,
   );
   diffs.forEach((diff) => {
-    currentSML.applyDiff(diff);
+    createdList.applyDiff(diff);
   });
-  return currentSML;
+  return createdList;
 };
 
 module.exports = SimplifiedMNListStore;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now the current pre-generated SimplifiedMasternodeList is returned if the tip height is used. This is an optimization for speed in that the current SML doesn't have to be generated anymore with the time consuming process of applying one diff after another to the base SML.

## What was done?
<!--- Describe your changes in detail -->
Refactored getSMLbyHeight
Return currentSML if height equals tip height

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
