### PR TITLE
fix: SimplifiedMNList clobbering global vars

### DIFF
--- a/lib/deterministicmnlist/SimplifiedMNList.js
+++ b/lib/deterministicmnlist/SimplifiedMNList.js
@@ -139,7 +139,7 @@ SimplifiedMNList.prototype.addAndMaybeRemoveQuorums = function addAndMaybeRemove
     var hits = this.quorumList.filter(quorum => quorum.llmqType === type);
     return { llmqType: type, quorums: hits };
   });
-  i = 0;
+  var i = 0;
   newQuorumsByType.forEach(function (quorumsByType) {
     quorumsByType.quorums.forEach(function (quorum) {
       if (quorumListByType[i].quorums.length === quorum.getParams().activeCount) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
https://github.com/dashevo/js-dash-sdk/issues/143

## What was done?
add a var to a variable declaration

## How Has This Been Tested?
tested with code from https://github.com/dashevo/js-dash-sdk/issues/143

## Breaking Changes
none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
