### PR TITLE
refactor: reuse method `.fromString` in `.fromHex`

### DIFF
--- a/lib/chainlock/chainlock.js
+++ b/lib/chainlock/chainlock.js
@@ -116,7 +116,7 @@ class ChainLock {
    * @return {ChainLock} - An instance of ChainLock
    */
   static fromHex(string) {
-    return ChainLock.fromBuffer(Buffer.from(string, 'hex'));
+    return ChainLock.fromString(string);
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cleaner code

## What was done?
<!--- Describe your changes in detail -->
Reuse the .fromString method in .fromHex instead of duplicating the code

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
