### PR TITLE
refactor: move all quorum validation to a single place

### DIFF
--- a/lib/deterministicmnlist/QuorumEntry.js
+++ b/lib/deterministicmnlist/QuorumEntry.js
@@ -230,50 +230,53 @@ QuorumEntry.prototype.toObject = function toObject() {
   };
 };
 
+QuorumEntry.getParams = function getParams(llmqType) {
+  const params = {};
+  switch (llmqType) {
+    case constants.LLMQ_TYPES.LLMQ_TYPE_50_60:
+      params.size = 50;
+      params.threshold = 30;
+      params.maximumActiveQuorumsCount = 24;
+      return params;
+    case constants.LLMQ_TYPES.LLMQ_TYPE_400_60:
+      params.size = 400;
+      params.threshold = 240;
+      params.maximumActiveQuorumsCount = 4;
+      return params;
+    case constants.LLMQ_TYPES.LLMQ_TYPE_400_85:
+      params.size = 400;
+      params.threshold = 340;
+      params.maximumActiveQuorumsCount = 4;
+      return params;
+    case constants.LLMQ_TYPES.LLMQ_TYPE_100_67:
+      params.size = 100;
+      params.threshold = 67;
+      params.maximumActiveQuorumsCount = 24;
+      return params;
+    case constants.LLMQ_TYPES.LLMQ_TYPE_LLMQ_TEST:
+      params.size = 3;
+      params.threshold = 2;
+      params.maximumActiveQuorumsCount = 2;
+      return params;
+    case constants.LLMQ_TYPES.LLMQ_TYPE_LLMQ_DEVNET:
+      params.size = 10;
+      params.threshold = 3;
+      params.maximumActiveQuorumsCount = 7;
+      return params;
+    case constants.LLMQ_TYPES.LLMQ_TYPE_TEST_V17:
+      params.size = 3;
+      params.threshold = 2;
+      params.maximumActiveQuorumsCount = 2;
+      return params;
+    default:
+      throw new Error(`Invalid llmq type ${llmqType}`);
+  }
+};
 /**
  * @return {number}
  */
 QuorumEntry.prototype.getParams = function getParams() {
-  const params = {};
-  switch (this.llmqType) {
-    case constants.LLMQ_TYPES.LLMQ_TYPE_50_60:
-      params.activeCount = 24;
-      params.size = 50;
-      params.threshold = 30;
-      return params;
-    case constants.LLMQ_TYPES.LLMQ_TYPE_400_60:
-      params.activeCount = 4;
-      params.size = 400;
-      params.threshold = 240;
-      return params;
-    case constants.LLMQ_TYPES.LLMQ_TYPE_400_85:
-      params.activeCount = 4;
-      params.size = 400;
-      params.threshold = 340;
-      return params;
-    case constants.LLMQ_TYPES.LLMQ_TYPE_100_67:
-      params.activeCount = 24;
-      params.size = 100;
-      params.threshold = 67;
-      return params;
-    case constants.LLMQ_TYPES.LLMQ_TYPE_LLMQ_TEST:
-      params.activeCount = 2;
-      params.size = 3;
-      params.threshold = 2;
-      return params;
-    case constants.LLMQ_TYPES.LLMQ_TYPE_LLMQ_DEVNET:
-      params.activeCount = 3;
-      params.size = 10;
-      params.threshold = 6;
-      return params;
-    case constants.LLMQ_TYPES.LLMQ_TYPE_TEST_V17:
-      params.activeCount = 2;
-      params.size = 3;
-      params.threshold = 2;
-      return params;
-    default:
-      throw new Error('Unknown llmq type');
-  }
+  return QuorumEntry.getParams(this.llmqType);
 };
 
 /**

--- a/lib/deterministicmnlist/SimplifiedMNList.js
+++ b/lib/deterministicmnlist/SimplifiedMNList.js
@@ -144,8 +144,8 @@ SimplifiedMNList.prototype.addAndMaybeRemoveQuorums = function addAndMaybeRemove
   let i = 0;
   newQuorumsByType.forEach((quorumsByType) => {
     quorumsByType.quorums.forEach((quorum) => {
-      if (quorumListByType[i].quorums.length === quorum.getParams().activeCount) {
-        throw new Error(`Trying to add more quorums to quorum type ${quorum.llmqType} than its activeCount of ${quorum.getParams().activeCount} permits`);
+      if (quorumListByType[i].quorums.length === quorum.getParams().maximumActiveQuorumsCount) {
+        throw new Error(`Trying to add more quorums to quorum type ${quorum.llmqType} than its maximumActiveQuorumsCount of ${quorum.getParams().maximumActiveQuorumsCount} permits`);
       }
       quorumListByType[i].quorums.push(quorum);
     });

--- a/lib/transaction/payload/commitmenttxpayload.js
+++ b/lib/transaction/payload/commitmenttxpayload.js
@@ -7,6 +7,7 @@ var Preconditions = require('../../util/preconditions');
 var BufferWriter = require('../../encoding/bufferwriter');
 var BufferReader = require('../../encoding/bufferreader');
 var AbstractPayload = require('./abstractpayload');
+var QuorumEntry = require('../../deterministicmnlist/QuorumEntry');
 
 var CURRENT_PAYLOAD_VERSION = 1;
 
@@ -166,32 +167,8 @@ CommitmentTxPayload.prototype.toJSON = function toJSON(options) {
 CommitmentTxPayload.prototype.toBuffer = function toBuffer(options) {
   this.validate();
 
-  var signerSizeLength = 50;
-  var validMemberSizeLength = 50;
-  // https://github.com/dashpay/dash/blob/develop/src/consensus/params.h#L42-L52
-  // the following works at least for the dummy commitments on testnet.
-  // TODO: revisit for actual commitments once live
-  switch(this.llmqtype) {
-    case 1:
-      signerSizeLength = 50;
-      validMemberSizeLength = 50;
-      break;
-    case 2:
-      signerSizeLength = 400;
-      validMemberSizeLength = 400;
-      break;
-    case 3:
-      signerSizeLength = 400;
-      validMemberSizeLength = 400;
-      break;
-    case 100:
-    case 101: // LLMQ_DEVNET
-      signerSizeLength = 10;
-      validMemberSizeLength = 10;
-      break;
-    default:
-      throw new Error('Invalid llmq type ' + this.llmqtype);
-  }
+  // This will validate quorum type
+  QuorumEntry.getParams(this.llmqtype);
 
   var payloadBufferWriter = new BufferWriter();
   payloadBufferWriter

--- a/test/deterministicmnlist/SimplifiedMNList.js
+++ b/test/deterministicmnlist/SimplifiedMNList.js
@@ -216,11 +216,11 @@ describe('SimplifiedMNList', function () {
           expect(quorums.length).to.be.equal(1);
         });
     });
-    it("Should throw an error if we are adding more quorums than activeCount for a particular llmqType permits", function () {
+    it("Should throw an error if we are adding more quorums than maximumActiveQuorumsCount for a particular llmqType permits", function () {
       var mnList = new SimplifiedMNList(SMNListFixture.getFirstDiff());
       expect(function () {
         mnList.applyDiff(SMNListFixture.getDiffThatAddsMoreThanDeletes());
-      }).to.throw('Trying to add more quorums to quorum type 2 than its activeCount of 4 permits');
+      }).to.throw('Trying to add more quorums to quorum type 2 than its maximumActiveQuorumsCount of 4 permits');
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- CommitementTxPayload not compatible with the dashcore v0.17

## What was done?
<!--- Describe your changes in detail -->
- replace quorum validation logic from CommitementTxPayload to a unified method in QuorumEntry
- rename quorum params `activeCount` to  `maximumActiveQuorumsCount` for better readability

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
