### PR TITLE
fix: chainlock hash endianness

### DIFF
--- a/lib/chainlock/chainlock.js
+++ b/lib/chainlock/chainlock.js
@@ -30,7 +30,7 @@ class ChainLock {
     const info = ChainLock._from(arg);
 
     this.height = info.height;
-    this.blockHash = Buffer.from(info.blockHash).reverse();
+    this.blockHash = info.blockHash;
     this.signature = info.signature;
 
     return this;
@@ -65,7 +65,7 @@ class ChainLock {
     let blockHash = data.blockHash || data.blockhash;
     let { signature } = data;
     if (isString(blockHash)) {
-      blockHash = BufferUtil.reverse(Buffer.from(blockHash, 'hex'));
+      blockHash = Buffer.from(blockHash, 'hex');
     }
 
     if (isString(data.signature)) {
@@ -86,7 +86,7 @@ class ChainLock {
   static _fromBufferReader(br) {
     const info = {};
     info.height = br.readInt32LE();
-    info.blockHash = br.read(SHA256_HASH_SIZE);
+    info.blockHash = Buffer.from(br.read(SHA256_HASH_SIZE)).reverse();
     info.signature = br.read(BLS_SIGNATURE_SIZE);
     return info;
   }
@@ -334,8 +334,7 @@ class ChainLock {
    * @returns {string} ChainLock block hash and height
    */
   inspect() {
-    const reversedBlockHash = BufferUtil.reverse(this.blockHash).toString('hex');
-    return `<ChainLock: ${reversedBlockHash}, height: ${this.height}>`;
+    return `<ChainLock: ${this.blockHash.toString('hex')}, height: ${this.height}>`;
   }
 }
 

--- a/lib/chainlock/chainlock.js
+++ b/lib/chainlock/chainlock.js
@@ -30,7 +30,7 @@ class ChainLock {
     const info = ChainLock._from(arg);
 
     this.height = info.height;
-    this.blockHash = info.blockHash;
+    this.blockHash = Buffer.from(info.blockHash).reverse();
     this.signature = info.signature;
 
     return this;
@@ -215,7 +215,7 @@ class ChainLock {
    * @returns {Buffer}
    */
   getHash() {
-    return doubleSha256(this.toBuffer()).reverse();
+    return doubleSha256(this.toBuffer());
   }
 
   /**
@@ -268,7 +268,7 @@ class ChainLock {
     bufferWriter.writeUInt8(llmqType);
     bufferWriter.writeReverse(Buffer.from(quorumHash, 'hex'));
     bufferWriter.writeReverse(requestId);
-    bufferWriter.write(blockHash);
+    bufferWriter.write(Buffer.from(blockHash).reverse());
     return doubleSha256(bufferWriter.toBuffer());
   }
 
@@ -279,7 +279,7 @@ class ChainLock {
   toObject() {
     return {
       height: this.height,
-      blockHash: BufferUtil.reverse(this.blockHash).toString('hex'),
+      blockHash: this.blockHash.toString('hex'),
       signature: this.signature.toString('hex'),
     };
   }
@@ -315,7 +315,7 @@ class ChainLock {
   toBufferWriter(bw) {
     const bufferWriter = bw || new BufferWriter();
     bufferWriter.writeInt32LE(this.height);
-    bufferWriter.write(this.blockHash);
+    bufferWriter.write(Buffer.from(this.blockHash).reverse());
     bufferWriter.write(this.signature);
     return bufferWriter;
   }

--- a/lib/chainlock/chainlock.js
+++ b/lib/chainlock/chainlock.js
@@ -86,7 +86,7 @@ class ChainLock {
   static _fromBufferReader(br) {
     const info = {};
     info.height = br.readInt32LE();
-    info.blockHash = Buffer.from(br.read(SHA256_HASH_SIZE)).reverse();
+    info.blockHash = br.readReverse(SHA256_HASH_SIZE);
     info.signature = br.read(BLS_SIGNATURE_SIZE);
     return info;
   }
@@ -268,7 +268,7 @@ class ChainLock {
     bufferWriter.writeUInt8(llmqType);
     bufferWriter.writeReverse(Buffer.from(quorumHash, 'hex'));
     bufferWriter.writeReverse(requestId);
-    bufferWriter.write(Buffer.from(blockHash).reverse());
+    bufferWriter.writeReverse(blockHash);
     return doubleSha256(bufferWriter.toBuffer());
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.19.12",
+  "version": "0.19.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.19.12",
+  "version": "0.19.13",
   "description": "A pure and powerful JavaScript Dash library.",
   "author": "Dash Core Group, Inc. <dev@dash.org>",
   "main": "index.js",

--- a/test/chainlock/chainlock.js
+++ b/test/chainlock/chainlock.js
@@ -50,7 +50,7 @@ describe('ChainLock', function () {
       signature: '0a43f1c3e5b3e8dbd670bca8d437dc25572f72d8e1e9be673e9ebbb606570307c3e5f5d073f7beb209dd7e0b8f96c751060ab3a7fb69a71d5ccab697b8cfa5a91038a6fecf76b7a827d75d17f01496302942aa5e2c7f4a48246efc8d3941bf6c'
     };
     buf2 = Buffer.from(str2, 'hex');
-    expectedHash2 = "3764ada6c32f09bb4f02295415b230657720f8be17d6fe046f0f8bf3db72b8e0";
+    expectedHash2 = "e0b872dbf38b0f6f04fed617bef820776530b2155429024fbb092fc3a6ad6437";
     expectedRequestId2 = "5d92e094e2aa582b76e8bf519f42c5e8fc141bbe548e9660726f744adad03966";
 
     // DashSync test vectors : https://github.com/dashevo/dashsync-iOS/blob/master/Example/Tests/DSChainLockTests.m


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixed ChainLock interface exposing reversed hashes

## What was done?
<!--- Describe your changes in detail -->
Change endianness of the `hash` property of the `ChanLock` class

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
- `ChainLock#hash` is now big-endian

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
