### PR TITLE
fix: crash is there's no signatory candidate when verifying chainlock

### DIFF
--- a/lib/chainlock/chainlock.js
+++ b/lib/chainlock/chainlock.js
@@ -171,11 +171,14 @@ class ChainLock {
    */
   async verifySignatureWithQuorumOffset(smlStore, requestId, offset) {
     const candidateSignatoryQuorum = this.selectSignatoryQuorum(smlStore, requestId, offset);
+    let result = false;
 
-    // Logic taken from dashsync-iOS
-    // https://github.com/dashevo/dashsync-iOS/blob/master/DashSync/Models/Chain/DSChainLock.m#L148-L185
-    // first try with default offset
-    let result = await this.verifySignatureAgainstQuorum(candidateSignatoryQuorum, requestId);
+    if (candidateSignatoryQuorum != null) {
+      // Logic taken from dashsync-iOS
+      // https://github.com/dashevo/dashsync-iOS/blob/master/DashSync/Models/Chain/DSChainLock.m#L148-L185
+      // first try with default offset
+      result = await this.verifySignatureAgainstQuorum(candidateSignatoryQuorum, requestId);
+    }
 
     // second try with 0 offset, else with double offset
     if (!result && offset === constants.LLMQ_SIGN_HEIGHT_OFFSET) {
@@ -242,13 +245,17 @@ class ChainLock {
    * @param {SimplifiedMNListStore} smlStore - used to reconstruct quorum lists
    * @param {Buffer} requestId
    * @param {number} offset
-   * @returns {QuorumEntry} - signatoryQuorum
+   * @returns {QuorumEntry|null} - signatoryQuorum
    */
   selectSignatoryQuorum(smlStore, requestId, offset) {
     const chainlockSML = smlStore.getSMLbyHeight(this.height - offset);
     const scoredQuorums = chainlockSML.calculateSignatoryQuorumScores(
       chainlockSML.getChainlockLLMQType(), requestId,
     );
+
+    if (scoredQuorums.length === 0) {
+      return null;
+    }
 
     scoredQuorums.sort((a, b) => Buffer.compare(a.score, b.score));
     return scoredQuorums[0].quorum;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.19.14",
+  "version": "0.19.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.19.14",
+  "version": "0.19.15",
   "description": "A pure and powerful JavaScript Dash library.",
   "author": "Dash Core Group, Inc. <dev@dash.org>",
   "main": "index.js",

--- a/test/chainlock/chainlock.js
+++ b/test/chainlock/chainlock.js
@@ -6,9 +6,11 @@ const expect = chai.expect;
 
 const bitcore = require('../../index');
 const SimplifiedMNListStore = require('../../lib/deterministicmnlist/SimplifiedMNListStore');
+const SimplifiedMNList = require('../../lib/deterministicmnlist/SimplifiedMNList');
 const SMNListFixture = require('../fixtures/mnList');
 const ChainLock = bitcore.ChainLock;
 const QuorumEntry = bitcore.QuorumEntry;
+const Networks = bitcore.Networks;
 
 describe('ChainLock', function () {
   let object;
@@ -166,6 +168,18 @@ describe('ChainLock', function () {
         const SMLStore = new SimplifiedMNListStore(smlDiffArray);
         const isValid = await chainLock.verify(SMLStore);
         expect(isValid).to.equal(true);
+      });
+      it("should return false if SML store does not have a signatory candidate", async function () {
+        const chainLock = new ChainLock(buf4);
+        const smlDiffArray = SMNListFixture.getChainlockDiffArray();
+        const SMLStore = new SimplifiedMNListStore(smlDiffArray);
+        SMLStore.getSMLbyHeight = function () {
+          var sml = new SimplifiedMNList();
+          sml.network = Networks.testnet;
+          return sml;
+        };
+        const isValid = await chainLock.verify(SMLStore);
+        expect(isValid).to.equal(false);
       });
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Crash in chainlock.verify if there's no signatory candidate

## What was done?
<!--- Describe your changes in detail -->
Add a condition to set `result` to `false` if there's no signatory candidate instead of proceeding with verification

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add new test for that condition

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
