### PR TITLE
fix: instantlock#verify crashing if bls lib can't parse the signature

### DIFF
--- a/lib/chainlock/chainlock.js
+++ b/lib/chainlock/chainlock.js
@@ -146,20 +146,11 @@ class ChainLock {
    * @returns {Promise<Boolean>} - returns the result of the signature verification
    */
   async verifySignatureAgainstQuorum(quorumEntry, requestId) {
-    const { signature } = this;
-    const { quorumPublicKey } = quorumEntry;
-    const signHash = this.getSignHashForQuorumEntry(quorumEntry, requestId);
-
-    const blsInstance = await bls.getInstance();
-
-    const quorumPubKey = blsInstance.PublicKey.fromBytes(Buffer.from(quorumPublicKey, 'hex'));
-
-    const aggregationInfo = blsInstance.AggregationInfo.fromMsgHash(quorumPubKey, signHash);
-    const thresholdSignature = blsInstance.Signature.fromBytes(Buffer.from(signature, 'hex'));
-
-    thresholdSignature.setAggregationInfo(aggregationInfo);
-
-    return thresholdSignature.verify();
+    return bls.verifySignature(
+      this.signature.toString('hex'),
+      this.getSignHashForQuorumEntry(quorumEntry, requestId),
+      quorumEntry.quorumPublicKey,
+    );
   }
 
   /**

--- a/lib/crypto/bls.js
+++ b/lib/crypto/bls.js
@@ -32,6 +32,43 @@ const bls = {
       }
     });
   },
+  /**
+   * Validate bls signature
+   * @param {string} signatureHex
+   * @param {Uint8Array} messageHash
+   * @param {string} publicKeyHex
+   * @return {Promise<boolean>}
+   */
+  async verifySignature(signatureHex, messageHash, publicKeyHex) {
+    const blsInstance = await this.getInstance();
+    let result = false;
+
+    let thresholdSignature;
+    let quorumPubKey;
+    let aggregationInfo;
+
+    try {
+      thresholdSignature = blsInstance.Signature.fromBytes(Uint8Array.from(Buffer.from(signatureHex, 'hex')));
+      quorumPubKey = blsInstance.PublicKey.fromBytes(Uint8Array.from(Buffer.from(publicKeyHex, 'hex')));
+      aggregationInfo = blsInstance.AggregationInfo.fromMsgHash(quorumPubKey, messageHash);
+
+      thresholdSignature.setAggregationInfo(aggregationInfo);
+
+      result = thresholdSignature.verify();
+    } catch (e) {
+      // This line is because BLS is a c++ WebAssembly binding, it will throw
+      // cryptic error messages if it fails to parse the signature.
+      return result;
+    } finally {
+      // Values from emscripten compiled code can't be garbage collected in JS,
+      // so they have to be released first using .delete method
+      if (thresholdSignature) { thresholdSignature.delete(); }
+      if (quorumPubKey) { quorumPubKey.delete(); }
+      if (aggregationInfo) { aggregationInfo.delete(); }
+    }
+
+    return result;
+  },
 };
 
 module.exports = bls;

--- a/lib/deterministicmnlist/QuorumEntry.js
+++ b/lib/deterministicmnlist/QuorumEntry.js
@@ -300,27 +300,18 @@ QuorumEntry.prototype.getCommitmentHash = function getCommitmentHash() {
  * Verifies the quorum's bls threshold signature
  * @return {Promise<boolean>}
  */
-QuorumEntry.prototype.isValidQuorumSig = function isValidQuorumSig() {
-  return new Promise((resolve, reject) => {
-    if (this.isOutdatedRPC) {
-      return reject(new Error('Quorum cannot be verified: node running on outdated DashCore version (< 0.16)'));
-    }
+QuorumEntry.prototype.isValidQuorumSig = async function isValidQuorumSig() {
+  if (this.isOutdatedRPC) {
+    throw new Error('Quorum cannot be verified: node running on outdated DashCore version (< 0.16)');
+  }
 
-    return bls.getInstance().then((blsInstance) => {
-      const quorumPubKey = blsInstance.PublicKey.fromBytes(Uint8Array.from(Buffer.from(this.quorumPublicKey, 'hex')));
-      const msgHash = Uint8Array.from(this.getCommitmentHash());
-      const aggregationInfo = blsInstance.AggregationInfo.fromMsgHash(quorumPubKey, msgHash);
-      const thresholdSignature = blsInstance.Signature.fromBytes(Uint8Array.from(Buffer.from(this.quorumSig, 'hex')));
+  const result = await bls.verifySignature(
+    this.quorumSig,
+    Uint8Array.from(this.getCommitmentHash()),
+    this.quorumPublicKey,
+  );
 
-      thresholdSignature.setAggregationInfo(aggregationInfo);
-
-      const result = thresholdSignature.verify();
-      quorumPubKey.delete();
-      thresholdSignature.delete();
-      aggregationInfo.delete();
-      resolve(result);
-    });
-  });
+  return result;
 };
 
 /**

--- a/lib/deterministicmnlist/QuorumEntry.js
+++ b/lib/deterministicmnlist/QuorumEntry.js
@@ -305,13 +305,11 @@ QuorumEntry.prototype.isValidQuorumSig = async function isValidQuorumSig() {
     throw new Error('Quorum cannot be verified: node running on outdated DashCore version (< 0.16)');
   }
 
-  const result = await bls.verifySignature(
+  return bls.verifySignature(
     this.quorumSig,
     Uint8Array.from(this.getCommitmentHash()),
     this.quorumPublicKey,
   );
-
-  return result;
 };
 
 /**

--- a/lib/instantlock/instantlock.js
+++ b/lib/instantlock/instantlock.js
@@ -147,20 +147,26 @@ class InstantLock {
    * @returns {Promise<Boolean>} - returns the result of the signature verification
    */
   async verifySignatureAgainstQuorum(quorumEntry, requestId) {
+    let result = false;
     const { signature } = this;
     const { quorumPublicKey } = quorumEntry;
     const signHash = this.getSignHashForQuorumEntry(quorumEntry, requestId);
 
     const blsInstance = await bls.getInstance();
 
-    const quorumPubKey = blsInstance.PublicKey.fromBytes(Buffer.from(quorumPublicKey, 'hex'));
+    try {
+      const quorumPubKey = blsInstance.PublicKey.fromBytes(Buffer.from(quorumPublicKey, 'hex'));
+      const aggregationInfo = blsInstance.AggregationInfo.fromMsgHash(quorumPubKey, signHash);
+      const thresholdSignature = blsInstance.Signature.fromBytes(Buffer.from(signature, 'hex'));
+      thresholdSignature.setAggregationInfo(aggregationInfo);
+      result = thresholdSignature.verify();
+    } catch (e) {
+      // This line is because BLS is a c++ WebAssembly binding, it will throw
+      // cryptic error messages if it fails to parse the signature.
+      return result;
+    }
 
-    const aggregationInfo = blsInstance.AggregationInfo.fromMsgHash(quorumPubKey, signHash);
-    const thresholdSignature = blsInstance.Signature.fromBytes(Buffer.from(signature, 'hex'));
-
-    thresholdSignature.setAggregationInfo(aggregationInfo);
-
-    return thresholdSignature.verify();
+    return result;
   }
 
   /**

--- a/lib/instantlock/instantlock.js
+++ b/lib/instantlock/instantlock.js
@@ -147,26 +147,11 @@ class InstantLock {
    * @returns {Promise<Boolean>} - returns the result of the signature verification
    */
   async verifySignatureAgainstQuorum(quorumEntry, requestId) {
-    let result = false;
-    const { signature } = this;
-    const { quorumPublicKey } = quorumEntry;
-    const signHash = this.getSignHashForQuorumEntry(quorumEntry, requestId);
-
-    const blsInstance = await bls.getInstance();
-
-    try {
-      const quorumPubKey = blsInstance.PublicKey.fromBytes(Buffer.from(quorumPublicKey, 'hex'));
-      const aggregationInfo = blsInstance.AggregationInfo.fromMsgHash(quorumPubKey, signHash);
-      const thresholdSignature = blsInstance.Signature.fromBytes(Buffer.from(signature, 'hex'));
-      thresholdSignature.setAggregationInfo(aggregationInfo);
-      result = thresholdSignature.verify();
-    } catch (e) {
-      // This line is because BLS is a c++ WebAssembly binding, it will throw
-      // cryptic error messages if it fails to parse the signature.
-      return result;
-    }
-
-    return result;
+    return bls.verifySignature(
+      this.signature,
+      this.getSignHashForQuorumEntry(quorumEntry, requestId),
+      quorumEntry.quorumPublicKey,
+    );
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.19.15",
+  "version": "0.19.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-lib",
-  "version": "0.19.15",
+  "version": "0.19.16",
   "description": "A pure and powerful JavaScript Dash library.",
   "author": "Dash Core Group, Inc. <dev@dash.org>",
   "main": "index.js",

--- a/test/chainlock/chainlock.js
+++ b/test/chainlock/chainlock.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const chai = require('chai');
-const should = chai.should();
 const expect = chai.expect;
 
 const bitcore = require('../../index');

--- a/test/deterministicmnlist/QuorumEntry.js
+++ b/test/deterministicmnlist/QuorumEntry.js
@@ -40,6 +40,7 @@ var commitmentHash = "bc8c5dc5975ce6c4988ce8506ce6a4ec59b3232a8715aa2ffaeeebab8d
 var selectionModifier = "c6a87d306a29918722342ddd612262356097b50b3d67476f073c33947aee32f0";
 
 describe('QuorumEntry', function () {
+  this.timeout(10000);
   describe('fromBuffer', function () {
     it('Should be able to parse data from a buffer', function () {
       var entry = QuorumEntry.fromBuffer(Buffer.from(quorumEntryHex, 'hex'));

--- a/test/deterministicmnlist/SimplifiedMNList.js
+++ b/test/deterministicmnlist/SimplifiedMNList.js
@@ -8,7 +8,7 @@ var constants = require('../../lib/constants');
 var Networks = require('../../lib/networks');
 
 describe('SimplifiedMNList', function () {
-  this.timeout(5000);
+  this.timeout(10000);
 
   describe('constructor', function () {
     it('Should call applyDiff with the first argument passed to the constructor', function () {

--- a/test/instantlock/instantlock.js
+++ b/test/instantlock/instantlock.js
@@ -11,6 +11,7 @@ const InstantLock = bitcore.InstantLock;
 const QuorumEntry = bitcore.QuorumEntry;
 
 describe('InstantLock', function () {
+  this.timeout(10000);
   let object;
   let str;
   let buf;
@@ -137,7 +138,6 @@ describe('InstantLock', function () {
       });
     });
     describe('#verify', function () {
-      this.timeout(6000);
       it('should verify signature against SMLStore', async function () {
         const instantLock = new InstantLock(buf2);
         const smlDiffArray = SMNListFixture.getInstantLockDiffArray();
@@ -145,6 +145,15 @@ describe('InstantLock', function () {
         const isValid = await instantLock.verify(SMLStore);
         expect(isValid).to.equal(true);
       });
+      it('should not crash if BLS fails to parse the signature or any other data', async function () {
+        const instantLock = new InstantLock(buf2);
+        expect(instantLock.signature.length).to.be.equal(192);
+        instantLock.signature = '0'.repeat(192);
+        const smlDiffArray = SMNListFixture.getInstantLockDiffArray();
+        const SMLStore = new SimplifiedMNListStore(smlDiffArray);
+        const isValid = await instantLock.verify(SMLStore);
+        expect(isValid).to.equal(false);
+      })
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- instantlock#verify crashing if bls lib can't parse the signature
- add `bls.verifySignature(signature: stringHex, messageHash: UInt8Array, publicKey: stringHex)` method to crypto/bls module

## What was done?
<!--- Describe your changes in detail -->
- Added new helper method to crypto/bls to add a unified way to verify signatures
- Replaced all places that verify BLS signatures to use the new helper method
- Added a new test to check crashes in bls lib

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Run the test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
