### PR TITLE
fix: PrivateKey toBuffer generates buffer without padding

### DIFF
--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -353,8 +353,7 @@ PrivateKey.prototype.toBigNumber = function () {
  * @returns {Buffer} A buffer of the private key
  */
 PrivateKey.prototype.toBuffer = function () {
-  // TODO: use `return this.bn.toBuffer({ size: 32 })` in v1.0.0
-  return this.bn.toBuffer();
+  return this.bn.toBuffer({ size: 32 });
 };
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PrivateKey.toBuffer generates buffers without padding. In some cases the resulting buffer can have wrong length, and its impossible to create an instance of PrivateKey from it.

## What was done?

<!--- Describe your changes in detail -->
Fixed PrivateKey.toBuffer method

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
