### PR TITLE
fix: false-positive detection of instant locks v18

### DIFF
--- a/lib/instantlock/instantlock.js
+++ b/lib/instantlock/instantlock.js
@@ -5,6 +5,7 @@ const BufferUtil = require('../util/buffer');
 const $ = require('../util/preconditions');
 const constants = require('../constants');
 const doubleSha256 = require('../crypto/hash').sha256sha256;
+const errors = require('../errors');
 
 const { isHexaString } = require('../util/js');
 const { validateV17, validateV18 } = require('./validation');
@@ -136,13 +137,9 @@ class InstantLock {
       result = InstantLock._fromBufferReaderV18(BufferReader(br.buf))
 
       // In case InstantLock v17 parsed without errors as InstantLock v18
-      try {
-        validateV18(result);
-      } catch (e) {
-        result = InstantLock._fromBufferReaderV17(BufferReader(br.buf));
-      }
+      validateV18(result);
     } catch (e) {
-      if (e.name === 'RangeError') {
+      if (e.name === 'RangeError' || e instanceof errors.InvalidArgument) {
         result = InstantLock._fromBufferReaderV17(BufferReader(br.buf));
       } else {
         throw e;

--- a/lib/instantlock/instantlock.js
+++ b/lib/instantlock/instantlock.js
@@ -6,7 +6,8 @@ const $ = require('../util/preconditions');
 const constants = require('../constants');
 const doubleSha256 = require('../crypto/hash').sha256sha256;
 
-const { isHexaString, isHexStringOfSize, isUnsignedInteger } = require('../util/js');
+const { isHexaString } = require('../util/js');
+const { validateV17, validateV18 } = require('./validation');
 
 const { SHA256_HASH_SIZE, BLS_SIGNATURE_SIZE } = constants;
 const bls = require('../crypto/bls');
@@ -133,6 +134,13 @@ class InstantLock {
     let result;
     try {
       result = InstantLock._fromBufferReaderV18(BufferReader(br.buf))
+
+      // In case InstantLock v17 parsed without errors as InstantLock v18
+      try {
+        validateV18(result);
+      } catch (e) {
+        result = InstantLock._fromBufferReaderV17(BufferReader(br.buf));
+      }
     } catch (e) {
       if (e.name === 'RangeError') {
         result = InstantLock._fromBufferReaderV17(BufferReader(br.buf));
@@ -140,7 +148,7 @@ class InstantLock {
         throw e;
       }
     }
-    
+
     return result;
   }
 
@@ -264,53 +272,13 @@ class InstantLock {
   }
 
   /**
-   *
-   * @private
-   */
-  _validateV17() {
-    $.checkArgument(
-      this.inputs.length > 0,
-      "TXs with no inputs can't be locked"
-    );
-    $.checkArgument(
-      isHexStringOfSize(this.inputs[0].outpointHash, SHA256_HASH_SIZE * 2),
-      `Expected outpointHash to be a hex string of size ${SHA256_HASH_SIZE}`
-    );
-    $.checkArgument(
-      isHexStringOfSize(this.txid.toString('hex'), SHA256_HASH_SIZE * 2),
-      `Expected txid to be a hex string of size ${SHA256_HASH_SIZE}`
-    );
-    $.checkArgument(
-      isHexStringOfSize(this.signature.toString('hex'), BLS_SIGNATURE_SIZE * 2),
-      'Expected signature to be a bls signature'
-    );
-  }
-
-  /**
-   *
-   * @private
-   */
-  _validateV18() {
-    this._validateV17();
-
-    $.checkArgument(
-      isUnsignedInteger(this.version),
-      "Expected version to be an unsigned integer"
-    );
-    $.checkArgument(
-      isHexStringOfSize(this.cyclehash.toString('hex'), SHA256_HASH_SIZE * 2),
-      `Expected cycleHash to be a hex string of size ${SHA256_HASH_SIZE}`
-    );
-  }
-
-  /**
    * Validate InstantLock structure
    */
   validate() {
     if (this.version === 1) {
-      this._validateV18();
+      validateV18(this);
     } else {
-      this._validateV17();
+      validateV17(this);
     }
   }
 

--- a/lib/instantlock/validation.js
+++ b/lib/instantlock/validation.js
@@ -1,0 +1,50 @@
+const $ = require('../util/preconditions');
+const { isHexStringOfSize, isUnsignedInteger } = require('../util/js');
+const constants = require('../constants');
+
+const { SHA256_HASH_SIZE, BLS_SIGNATURE_SIZE } = constants;
+
+/**
+ * Validates Instant Locks v17
+ * @param {InstantLock} instantLock
+ */
+function validateV17(instantLock) {
+  $.checkArgument(
+    instantLock.inputs.length > 0,
+    "TXs with no inputs can't be locked"
+  );
+  $.checkArgument(
+    isHexStringOfSize(instantLock.inputs[0].outpointHash, SHA256_HASH_SIZE * 2),
+    `Expected outpointHash to be a hex string of size ${SHA256_HASH_SIZE}`
+  );
+  $.checkArgument(
+    isHexStringOfSize(instantLock.txid.toString('hex'), SHA256_HASH_SIZE * 2),
+    `Expected txid to be a hex string of size ${SHA256_HASH_SIZE}`
+  );
+  $.checkArgument(
+    isHexStringOfSize(instantLock.signature.toString('hex'), BLS_SIGNATURE_SIZE * 2),
+    'Expected signature to be a bls signature'
+  );
+}
+
+/**
+ * Validates Instant Locks v18
+ * @param {InstantLock} instantLock
+ */
+function validateV18(instantLock) {
+  validateV17(instantLock);
+
+  $.checkArgument(
+    isUnsignedInteger(instantLock.version),
+    "Expected version to be an unsigned integer"
+  );
+  $.checkArgument(
+    isHexStringOfSize(instantLock.cyclehash.toString('hex'), SHA256_HASH_SIZE * 2),
+    `Expected cycleHash to be a hex string of size ${SHA256_HASH_SIZE}`
+  );
+}
+
+module.exports = {
+  validateV17,
+  validateV18
+}

--- a/test/instantlock/instantlock.js
+++ b/test/instantlock/instantlock.js
@@ -338,6 +338,25 @@ describe('InstantLock', function () {
           const instantLockJSON = instantLock.toObject();
           expect(instantLockJSON).to.be.deep.equal(object);
         });
+        it('should be able to handle false-positive v18', () => {
+          const instantLockString = '0104edf83df6cba7c6535272d91eeff5ff2eda5a579d51389b381e10f580ff80b7010000004d48cc7b66105699422fe0db7212c033a84fbc7dcf799550a1038ff6f30aa1220291fcfb6d44c06780ac475ce5cb3dd4c7f565888f485252cb4ae6ad206161b2f58655752c8e74f5ef627813870e94490fa7c1634361054fb1b81dd751a9dcd8419dc00dd17282729c474ecf4aae9053dbbcc43e02710f8f899db38be8d649e5'
+          const instantLockObject = {
+            inputs: [
+              {
+                outpointHash: 'b780ff80f5101e389b38519d575ada2efff5ef1ed9725253c6a7cbf63df8ed04',
+                outpointIndex: 1
+              }
+            ],
+            txid: '22a10af3f68f03a1509579cf7dbc4fa833c01272dbe02f42995610667bcc484d',
+            signature: '0291fcfb6d44c06780ac475ce5cb3dd4c7f565888f485252cb4ae6ad206161b2f58655752c8e74f5ef627813870e94490fa7c1634361054fb1b81dd751a9dcd8419dc00dd17282729c474ecf4aae9053dbbcc43e02710f8f899db38be8d649e5'
+          };
+
+          const instantLock = new InstantLock(instantLockString);
+          const string = instantLock.toString();
+          expect(string).to.equal(instantLockString);
+          const object = instantLock.toObject();
+          expect(object).to.be.deep.equal(instantLockObject);
+        })
       });
 
       describe('#fromObject', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Fixes a bug when certain InstantLocks v17 parsed as v18

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## What was done?
Validate v18 instant lock after the parsing. If validation fails, try parsing as v17
<!--- Describe your changes in detail -->

## How Has This Been Tested?
Added corresponding test case. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
