### PR TITLE
fix: error parsing instant locks v17

### DIFF
--- a/lib/instantlock/instantlock.js
+++ b/lib/instantlock/instantlock.js
@@ -5,7 +5,6 @@ const BufferUtil = require('../util/buffer');
 const $ = require('../util/preconditions');
 const constants = require('../constants');
 const doubleSha256 = require('../crypto/hash').sha256sha256;
-const errors = require('../errors');
 
 const { isHexaString } = require('../util/js');
 const { validateV17, validateV18 } = require('./validation');
@@ -139,11 +138,7 @@ class InstantLock {
       // In case InstantLock v17 parsed without errors as InstantLock v18
       validateV18(result);
     } catch (e) {
-      if (e.name === 'RangeError' || e instanceof errors.InvalidArgument) {
-        result = InstantLock._fromBufferReaderV17(BufferReader(br.buf));
-      } else {
-        throw e;
-      }
+      result = InstantLock._fromBufferReaderV17(BufferReader(br.buf));
     }
 
     return result;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
This fix makes Instant Locks v17 parsing more generalized.

The current algorithm first tries to interpret any instant lock bytes as v18 ones, and if a specific error is thrown, it falls back to v17 parsing.

Instead of handling specific errors coming from v18 parsing, it makes sense to fall back on v17 parsing in case of any error. 
This change makes the parsing algorithm simpler and eliminates the need of handling a variety of specific shapes of instant locks.

This fix is an addition to https://github.com/dashevo/dashcore-lib/pull/243

Possibly related: 
https://github.com/dashevo/platform/issues/218
https://github.com/dashevo/platform/issues/92


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## What was done?
Remove the check for specific errors in case parsing or validation of Instant Lock v18 fails and proceed directly to parsing as v17.

<!--- Describe your changes in detail -->

## How Has This Been Tested?
Via dashcore-lib test suite

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
