### PR TITLE
chore: add Core v0.18 quorums

### DIFF
--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -40,26 +40,47 @@ module.exports = {
   // In duffs
   INSTANTSEND_FEE_PER_INPUT: 10000,
   LLMQ_TYPES: {
-    LLMQ_TYPE_50_60: 1,
     // 50 members, 30 (60%) threshold, one per hour (24 blocks)
-    LLMQ_TYPE_400_60: 2,
+    LLMQ_TYPE_50_60: 1,
+
     // 400 members, 240 (60%) threshold, one every 12 hours (288 blocks)
-    LLMQ_TYPE_400_85: 3,
+    LLMQ_TYPE_400_60: 2,
+
     // 400 members, 340 (85%) threshold, one every 24 hours (576 blocks)
-    LLMQ_TYPE_100_67: 4,
+    LLMQ_TYPE_400_85: 3,
+
     // 100 members, 67 (67%) threshold, one every 24 hours (576 blocks)
-    LLMQ_TYPE_LLMQ_TEST: 100,
+    LLMQ_TYPE_100_67: 4,
+
+    // 60 members, 45 (75%) threshold, one every 12 hours
+    LLMQ_TYPE_60_75: 5,
+
     // 3 members, 2 (66%) threshold, one per hour (24 blocks)
     // Params might differ when -llmqtestparams is used
-    LLMQ_TYPE_LLMQ_DEVNET: 101,
+    LLMQ_TYPE_LLMQ_TEST: 100,
+
     // 10 members, 6 (60%) threshold, one per hour (24 blocks)
     // Params might differ when -llmqdevnetparams is used
+    LLMQ_TYPE_LLMQ_DEVNET: 101,
+
+    // 3 members, 2 (66%) threshold, one per hour.
+    // Params might differ when -llmqtestparams is used
     LLMQ_TYPE_TEST_V17: 102,
+
+    // 4 members, 2 (66%) threshold, one per hour.
+    // Params might differ when -llmqtestparams is used
+    LLMQ_TYPE_TEST_DIP0024: 103,
+
+    // 3 members, 2 (66%) threshold, one per hour.
+    // Params might differ when -llmqtestinstantsendparams is used
+    LLMQ_TYPE_TEST_INSTANTSEND: 104,
   },
-  LLMQ_SIGN_HEIGHT_OFFSET: 8,
 
   // when selecting a quorum for signing and verification, we use this offset as
   // starting height for scanning. This is because otherwise the resulting signatures
   // would not be verifiable by nodes which are not 100% at the chain tip.
-  SMLSTORE_MAX_DIFFS: 720, // keep diffs for 30 hours (720 blocks)
+  LLMQ_SIGN_HEIGHT_OFFSET: 8,
+
+  // keep diffs for 30 hours (720 blocks)
+  SMLSTORE_MAX_DIFFS: 720,
 };

--- a/lib/deterministicmnlist/QuorumEntry.js
+++ b/lib/deterministicmnlist/QuorumEntry.js
@@ -297,6 +297,11 @@ QuorumEntry.getParams = function getParams(llmqType) {
       params.threshold = 30;
       params.maximumActiveQuorumsCount = 24;
       return params;
+    case constants.LLMQ_TYPES.LLMQ_TYPE_60_75:
+      params.size = 60;
+      params.threshold = 45;
+      params.maximumActiveQuorumsCount = 32;
+      return params;
     case constants.LLMQ_TYPES.LLMQ_TYPE_400_60:
       params.size = 400;
       params.threshold = 240;
@@ -323,6 +328,16 @@ QuorumEntry.getParams = function getParams(llmqType) {
       params.maximumActiveQuorumsCount = 7;
       return params;
     case constants.LLMQ_TYPES.LLMQ_TYPE_TEST_V17:
+      params.size = 3;
+      params.threshold = 2;
+      params.maximumActiveQuorumsCount = 2;
+      return params;
+    case constants.LLMQ_TYPES.LLMQ_TYPE_TEST_DIP0024:
+      params.size = 4;
+      params.threshold = 2;
+      params.maximumActiveQuorumsCount = 2;
+      return params;
+    case constants.LLMQ_TYPES.LLMQ_TYPE_TEST_INSTANTSEND:
       params.size = 3;
       params.threshold = 2;
       params.maximumActiveQuorumsCount = 2;

--- a/lib/deterministicmnlist/SimplifiedMNList.js
+++ b/lib/deterministicmnlist/SimplifiedMNList.js
@@ -390,6 +390,7 @@ SimplifiedMNList.prototype.getLLMQTypes = function getLLMQTypes() {
         llmqTypes = [
           constants.LLMQ_TYPES.LLMQ_TYPE_LLMQ_TEST,
           constants.LLMQ_TYPES.LLMQ_TYPE_50_60,
+          constants.LLMQ_TYPES.LLMQ_TYPE_60_75,
           constants.LLMQ_TYPES.LLMQ_TYPE_TEST_V17,
           constants.LLMQ_TYPES.LLMQ_TYPE_TEST_INSTANTSEND,
           constants.LLMQ_TYPES.LLMQ_TYPE_TEST_DIP0024,
@@ -400,6 +401,7 @@ SimplifiedMNList.prototype.getLLMQTypes = function getLLMQTypes() {
       llmqTypes = [
         constants.LLMQ_TYPES.LLMQ_TYPE_LLMQ_DEVNET,
         constants.LLMQ_TYPES.LLMQ_TYPE_50_60,
+        constants.LLMQ_TYPES.LLMQ_TYPE_60_75,
         constants.LLMQ_TYPES.LLMQ_TYPE_400_60,
         constants.LLMQ_TYPES.LLMQ_TYPE_400_85,
         constants.LLMQ_TYPES.LLMQ_TYPE_TEST_V17,

--- a/lib/deterministicmnlist/SimplifiedMNList.js
+++ b/lib/deterministicmnlist/SimplifiedMNList.js
@@ -368,14 +368,17 @@ SimplifiedMNList.prototype.getLLMQTypes = function getLLMQTypes() {
     case Networks.livenet.name:
       llmqTypes = [
         constants.LLMQ_TYPES.LLMQ_TYPE_50_60,
+        constants.LLMQ_TYPES.LLMQ_TYPE_60_75,
         constants.LLMQ_TYPES.LLMQ_TYPE_400_60,
         constants.LLMQ_TYPES.LLMQ_TYPE_400_85,
+        constants.LLMQ_TYPES.LLMQ_TYPE_100_67,
       ];
       return llmqTypes;
     case Networks.testnet.name:
       if (this.mnList.length > 100) {
         llmqTypes = [
           constants.LLMQ_TYPES.LLMQ_TYPE_50_60,
+          constants.LLMQ_TYPES.LLMQ_TYPE_60_75,
           constants.LLMQ_TYPES.LLMQ_TYPE_400_60,
           constants.LLMQ_TYPES.LLMQ_TYPE_400_85,
           constants.LLMQ_TYPES.LLMQ_TYPE_TEST_V17,
@@ -388,6 +391,8 @@ SimplifiedMNList.prototype.getLLMQTypes = function getLLMQTypes() {
           constants.LLMQ_TYPES.LLMQ_TYPE_LLMQ_TEST,
           constants.LLMQ_TYPES.LLMQ_TYPE_50_60,
           constants.LLMQ_TYPES.LLMQ_TYPE_TEST_V17,
+          constants.LLMQ_TYPES.LLMQ_TYPE_TEST_INSTANTSEND,
+          constants.LLMQ_TYPES.LLMQ_TYPE_TEST_DIP0024,
         ];
         return llmqTypes;
       }
@@ -398,6 +403,8 @@ SimplifiedMNList.prototype.getLLMQTypes = function getLLMQTypes() {
         constants.LLMQ_TYPES.LLMQ_TYPE_400_60,
         constants.LLMQ_TYPES.LLMQ_TYPE_400_85,
         constants.LLMQ_TYPES.LLMQ_TYPE_TEST_V17,
+        constants.LLMQ_TYPES.LLMQ_TYPE_TEST_INSTANTSEND,
+        constants.LLMQ_TYPES.LLMQ_TYPE_TEST_DIP0024,
       ];
       return llmqTypes;
     default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To operate with Core 0.18 we need to recognize new quorums.

## What was done?
<!--- Describe your changes in detail -->
- Add LLMQ_TYPE_TEST_INSTANTSEND
- Add LLMQ_TYPE_60_75
- Add LLMQ_TYPE_TEST_DIP0024

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
