### PR TITLE
fix: can't parse `CommitmentTxPayload`

### DIFF
--- a/lib/transaction/payload/commitmenttxpayload.js
+++ b/lib/transaction/payload/commitmenttxpayload.js
@@ -18,6 +18,7 @@ var CURRENT_PAYLOAD_VERSION = 1;
  * @property {number} qfcVersion	uint16_t	2	Version of the final commitment message
  * @property {number} llmqtype	uint8_t	1	type of the long living masternode quorum
  * @property {string} quorumHash	uint256	32	The quorum identifier
+ * @property {number} quorumIndex	int16	2	The quorum index
  * @property {number} signersSize	compactSize uint	1-9	Bit size of the signers bitvector
  * @property {string} signers	byte[]	(bitSize + 7) / 8	Bitset representing the aggregated signers of this final commitment
  * @property {number} validMembersSize	compactSize uint	1-9	Bit size of the validMembers bitvector
@@ -35,6 +36,7 @@ var CURRENT_PAYLOAD_VERSION = 1;
  * @property {number} qfcVersion
  * @property {number} llmqtype
  * @property {string} quorumHash
+ * @property {number} quorumIndex
  * @property {number} signersSize
  * @property {string} signers
  * @property {number} validMembersSize
@@ -54,6 +56,7 @@ function CommitmentTxPayload(options) {
     this.qfcVersion = options.qfcVersion;
     this.llmqtype = options.llmqtype;
     this.quorumHash = options.quorumHash;
+    this.quorumIndex = options.quorumIndex;
     this.signers = options.signers;
     this.validMembers = options.validMembers;
     this.quorumPublicKey = options.quorumPublicKey;
@@ -83,6 +86,10 @@ CommitmentTxPayload.fromBuffer = function fromBuffer(rawPayload) {
   payload.quorumHash = payloadBufferReader
     .read(constants.SHA256_HASH_SIZE)
     .toString('hex');
+
+  if (payload.version >= constants.HASH_QUORUM_INDEX_REQUIRED_VERSION) {
+    payload.quorumIndex = payloadBufferReader.readInt16LE();
+  }
 
   payload.signersSize = payloadBufferReader.readVarintNum();
   var signersBytesToRead = Math.floor((payload.signersSize + 7) / 8) || 1;
@@ -157,6 +164,14 @@ CommitmentTxPayload.prototype.validate = function () {
     utils.isHexaString(this.quorumHash),
     'Expect quorumHash to be a hex string'
   );
+
+  if (this.version >= constants.HASH_QUORUM_INDEX_REQUIRED_VERSION) {
+    Preconditions.checkArgument(
+      Number.isInteger(this.quorumIndex),
+      'Expect quorumHash to be an integer'
+    );
+  }
+
   Preconditions.checkArgument(
     utils.isHexaString(this.signers),
     'Expect signers to be a hex string'
@@ -206,6 +221,10 @@ CommitmentTxPayload.prototype.toJSON = function toJSON(options) {
     sig: this.sig,
   };
 
+  if (this.version >= constants.HASH_QUORUM_INDEX_REQUIRED_VERSION) {
+    payloadJSON.quorumIndex = this.quorumIndex;
+  }
+
   return payloadJSON;
 };
 
@@ -226,7 +245,13 @@ CommitmentTxPayload.prototype.toBuffer = function toBuffer(options) {
     .writeUInt32LE(this.height)
     .writeUInt16LE(this.qfcVersion)
     .writeUInt8(this.llmqtype)
-    .write(Buffer.from(this.quorumHash, 'hex'))
+    .write(Buffer.from(this.quorumHash, 'hex'));
+
+  if (this.version >= constants.HASH_QUORUM_INDEX_REQUIRED_VERSION) {
+    payloadBufferWriter.writeInt16LE(this.quorumIndex);
+  }
+
+  payloadBufferWriter
     .writeVarintNum(this.signersSize)
     .write(Buffer.from(this.signers, 'hex'))
     .writeVarintNum(this.validMembersSize)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
Failed transaction parsing with error Failed to parse payload: raw payload is bigger than expected.. Transaction parameter: �Ae[��_�'�OW��B%�H�섏�)Wh�e


node:events:505
      throw er; // Unhandled 'error' event
      ^

Error: Failed to parse payload: raw payload is bigger than expected.
    at Function.fromBuffer (/platform/.yarn/cache/@dashevo-dashcore-lib-npm-0.19.32-5e9af4b646-5a21b2c7fe.zip/node_modules/@dashevo/dashcore-lib/lib/transaction/payload/commitmenttxpayload.js:114:11)
    at Object.parsePayloadBuffer [as parseBuffer] (/platform/.yarn/cache/@dashevo-dashcore-lib-npm-0.19.32-5e9af4b646-5a21b2c7fe.zip/node_modules/@dashevo/dashcore-lib/lib/transaction/payload/payload.js:63:18)
    at Transaction.fromBufferReader (/platform/.yarn/cache/@dashevo-dashcore-lib-npm-0.19.32-5e9af4b646-5a21b2c7fe.zip/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:404:36)
    at Transaction.fromBuffer (/platform/.yarn/cache/@dashevo-dashcore-lib-npm-0.19.32-5e9af4b646-5a21b2c7fe.zip/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:413:15)
    at new Transaction (/platform/.yarn/cache/@dashevo-dashcore-lib-npm-0.19.32-5e9af4b646-5a21b2c7fe.zip/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:59:14)
    at ZmqClient.testRawTransactionAgainstFilterCollection (/platform/packages/dapi/lib/transactionsFilter/testRawTransactionAgainstFilterCollectionFactory.js:15:25)
    at ZmqClient.emit (node:events:527:28)
    at exports.Socket.emit (node:events:527:28)
    at exports.Socket.Socket._emitMessage (/platform/.yarn/unplugged/zeromq-npm-5.2.8-213a0f74bc/node_modules/zeromq/lib/index.js:649:15)
    at exports.Socket.Socket._flushRead (/platform/.yarn/unplugged/zeromq-npm-5.2.8-213a0f74bc/node_modules/zeromq/lib/index.js:660:10)
Emitted 'error' event on  instance at:
    at exports.Socket.Socket._flushRead (/platform/.yarn/unplugged/zeromq-npm-5.2.8-213a0f74bc/node_modules/zeromq/lib/index.js:662:10)
    at exports.Socket.Socket._flushReads (/platform/.yarn/unplugged/zeromq-npm-5.2.8-213a0f74bc/node_modules/zeromq/lib/index.js:696:15)
    at Immediate.<anonymous> (/platform/.yarn/unplugged/zeromq-npm-5.2.8-213a0f74bc/node_modules/zeromq/lib/index.js:307:12)
    at processImmediate (node:internal/timers:466:21)
```


## What was done?
<!--- Describe your changes in detail -->
- Handle `quorumIndex` field for version 2 and bigger

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

None

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
