### PR TITLE
fix: use correct version field for qfcommit parsing

### DIFF
--- a/lib/transaction/payload/commitmenttxpayload.js
+++ b/lib/transaction/payload/commitmenttxpayload.js
@@ -14,7 +14,7 @@ var CURRENT_PAYLOAD_VERSION = 1;
 /**
  * @typedef {Object} CommitmentTxPayloadJSON
  * @property {number} version	uint16_t	2	Commitment special transaction version number. Currently set to 1. Please note that this is not the same as the version field of qfcommit
- * @property {number} height	uint16_t	2	The height of the block in which this commitment is included
+ * @property {number} height	int32_t	2	The height of the block in which this commitment is included
  * @property {number} qfcVersion	uint16_t	2	Version of the final commitment message
  * @property {number} llmqtype	uint8_t	1	type of the long living masternode quorum
  * @property {string} quorumHash	uint256	32	The quorum identifier
@@ -87,7 +87,7 @@ CommitmentTxPayload.fromBuffer = function fromBuffer(rawPayload) {
     .read(constants.SHA256_HASH_SIZE)
     .toString('hex');
 
-  if (payload.version >= constants.HASH_QUORUM_INDEX_REQUIRED_VERSION) {
+  if (payload.qfcVersion >= constants.HASH_QUORUM_INDEX_REQUIRED_VERSION) {
     payload.quorumIndex = payloadBufferReader.readInt16LE();
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Parsing of qfcommit was using the qctx version (which is still 1) instead of the qfcommit version

## What was done?
Switched to use the correct version field (also corrected a comment)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

Related to #252 