### PR TITLE
fix: incorrect parsing of commitment payload

### DIFF
--- a/lib/transaction/payload/commitmenttxpayload.js
+++ b/lib/transaction/payload/commitmenttxpayload.js
@@ -91,15 +91,17 @@ CommitmentTxPayload.fromBuffer = function fromBuffer(rawPayload) {
     payload.quorumIndex = payloadBufferReader.readInt16LE();
   }
 
+  const fixedCounterLength = QuorumEntry.getParams(payload.llmqtype).size;
+
   payload.signersSize = payloadBufferReader.readVarintNum();
-  var signersBytesToRead = Math.floor((payload.signersSize + 7) / 8) || 1;
+  var signersBytesToRead = Math.floor((fixedCounterLength + 7) / 8) || 1;
   payload.signers = payloadBufferReader
     .read(signersBytesToRead)
     .toString('hex');
 
   payload.validMembersSize = payloadBufferReader.readVarintNum();
   var validMembersBytesToRead =
-    Math.floor((payload.validMembersSize + 7) / 8) || 1;
+    Math.floor((fixedCounterLength + 7) / 8) || 1;
   payload.validMembers = payloadBufferReader
     .read(validMembersBytesToRead)
     .toString('hex');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Commitment payload is parsed incorrectly when `signersCount` and `validMembersCount` are not equal to LLMQ size


## What was done?

<!--- Describe your changes in detail -->
- Use LLMQ size to deseralize `signers` and `validMembers`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
