### PR TITLE
fix: `CommitmentTxPayload#toBuffer` method was using `version` instead of `qfcVersion` for serialization

### DIFF
--- a/lib/transaction/payload/commitmenttxpayload.js
+++ b/lib/transaction/payload/commitmenttxpayload.js
@@ -249,7 +249,7 @@ CommitmentTxPayload.prototype.toBuffer = function toBuffer(options) {
     .writeUInt8(this.llmqtype)
     .write(Buffer.from(this.quorumHash, 'hex'));
 
-  if (this.version >= constants.HASH_QUORUM_INDEX_REQUIRED_VERSION) {
+  if (this.qfcVersion >= constants.HASH_QUORUM_INDEX_REQUIRED_VERSION) {
     payloadBufferWriter.writeInt16LE(this.quorumIndex);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

`CommitmentTxPayload#toBuffer` method was using `version` instead of `qfcVersion` for serialization of `quorumIndex`

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## What was done?
- fixed an `if` statement

<!--- Describe your changes in detail -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
