### PR TITLE
feat: external configuration for crypto libs

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 // TODO: Remove previous line and work through linting issues at next edit
 
 'use strict';
+const { configure } = require('./lib/configuration');
 
 var bitcore = module.exports;
 
@@ -90,3 +91,4 @@ bitcore.deps._ = require('lodash');
 
 // Internal usage, exposed for testing/advanced tweaking
 bitcore.Transaction.sighash = require('./lib/transaction/sighash');
+bitcore.configure = configure;

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,0 +1,36 @@
+const x11hash = require('@dashevo/x11-hash-js');
+const crypto = require('crypto');
+
+/**
+ * @typedef {X11Hash} X11Hash
+ * @property {Object} errors
+ * @property {function((string|Array|buffer), number, number): (string|Array)} digest
+ */
+
+/**
+ * @typedef {Crypto} Crypto
+ * @property {function(string, HashOptions): Hash} createHash
+ */
+
+/**
+ * @typedef {DashCoreLibConfiguration} DashCoreLibConfiguration
+ * @property {X11Hash} [x11hash]
+ * @property {Crypto} [crypto]
+ */
+const configuration = {
+  x11hash,
+  crypto
+};
+
+/**
+ * Configures DashCore library
+ * @param {DashCoreLibConfiguration} config
+ */
+const configure = (config) => {
+  Object.assign(configuration, { ...config });
+}
+
+module.exports = {
+  configuration,
+  configure
+}

--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -3,8 +3,7 @@
 
 'use strict';
 
-var x11hash = require('@dashevo/x11-hash-js');
-var crypto = require('crypto');
+const { configuration } = require('../configuration');
 var BufferUtil = require('../util/buffer');
 var $ = require('../util/preconditions');
 
@@ -12,14 +11,14 @@ var Hash = module.exports;
 
 Hash.sha1 = function (buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return crypto.createHash('sha1').update(buf).digest();
+  return configuration.crypto.createHash('sha1').update(buf).digest();
 };
 
 Hash.sha1.blocksize = 512;
 
 Hash.sha256 = function (buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return crypto.createHash('sha256').update(buf).digest();
+  return configuration.crypto.createHash('sha256').update(buf).digest();
 };
 
 Hash.sha256.blocksize = 512;
@@ -31,12 +30,13 @@ Hash.sha256sha256 = function (buf) {
 
 Hash.x11 = function (buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return Buffer.from(x11hash.digest(buf, 1, 1));
+  const hash = configuration.x11hash.digest(buf, 1, 1);
+  return Buffer.from(hash);
 };
 
 Hash.ripemd160 = function (buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return crypto.createHash('ripemd160').update(buf).digest();
+  return configuration.crypto.createHash('ripemd160').update(buf).digest();
 };
 
 Hash.sha256ripemd160 = function (buf) {
@@ -46,7 +46,7 @@ Hash.sha256ripemd160 = function (buf) {
 
 Hash.sha512 = function (buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return crypto.createHash('sha512').update(buf).digest();
+  return configuration.crypto.createHash('sha512').update(buf).digest();
 };
 
 Hash.sha512.blocksize = 1024;

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "terser-webpack-plugin": "^4.1.0",
         "transform-loader": "^0.2.4",
         "url": "^0.11.0",
+        "wasm-x11-hash": "^0.0.2",
         "webpack": "^5.38.1",
         "webpack-cli": "^4.7.0"
       }
@@ -7595,6 +7596,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wasm-x11-hash": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wasm-x11-hash/-/wasm-x11-hash-0.0.2.tgz",
+      "integrity": "sha512-NOw8gd8J45FvNI/TunWKdPB1UG+/WDVckP4lP36Ffp1JY5Oo1nGq7K+0gdE75kzmhadEihBkIpchV3E0RESDwA==",
+      "dev": true
+    },
     "node_modules/watchpack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
@@ -14113,6 +14120,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "dev": true
+    },
+    "wasm-x11-hash": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wasm-x11-hash/-/wasm-x11-hash-0.0.2.tgz",
+      "integrity": "sha512-NOw8gd8J45FvNI/TunWKdPB1UG+/WDVckP4lP36Ffp1JY5Oo1nGq7K+0gdE75kzmhadEihBkIpchV3E0RESDwA==",
       "dev": true
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "terser-webpack-plugin": "^4.1.0",
     "transform-loader": "^0.2.4",
     "url": "^0.11.0",
-    "wasm-x11-hash": "~0.0.1",
+    "wasm-x11-hash": "^0.0.2",
     "webpack": "^5.38.1",
     "webpack-cli": "^4.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -87,6 +87,10 @@
     {
       "name": "Dashameter",
       "email": "Dashameter@gmail.com"
+    },
+    {
+      "name": "Igor Markin",
+      "email": "markin.io210@gmail.com"
     }
   ],
   "keywords": [
@@ -156,6 +160,7 @@
     "terser-webpack-plugin": "^4.1.0",
     "transform-loader": "^0.2.4",
     "url": "^0.11.0",
+    "wasm-x11-hash": "~0.0.1",
     "webpack": "^5.38.1",
     "webpack-cli": "^4.7.0"
   },

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -1,6 +1,8 @@
 const chai = require('chai');
 const X11 = require('wasm-x11-hash');
 const Hash = require('../lib/crypto/hash');
+const crypto = require('crypto');
+const x11hash = require('@dashevo/x11-hash-js');
 
 const { configure, BlockHeader } = require("../index");
 
@@ -23,6 +25,13 @@ describe('configuration', function () {
       }
     })
   });
+
+  after(() => {
+    configure({
+      x11hash,
+      crypto
+    })
+  })
 
   it('should use external x11 for block header hash', () => {
     const blockHeader = new BlockHeader(headerBuffer);

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -1,0 +1,36 @@
+const chai = require('chai');
+const X11 = require('wasm-x11-hash');
+const Hash = require('../lib/crypto/hash');
+
+const { configure, BlockHeader } = require("../index");
+
+const expect = chai.expect;
+
+const headerBuffer = Buffer.from('0400000097ea9c8bee806143a8ae50116fe3d329dcbb18b5d8ea71a7a213a1b052000000b1950f668df2593684169b0e33ee7fb1b8e00d90ed906d80b4c2baa7d1b65f548f495a57ed98521d348b0700','hex')
+describe('configuration', function () {
+  before(async () => {
+    const x11 = await X11();
+    configure({
+      x11hash: {
+        digest: (input) => x11.digest(input)
+      },
+      crypto: {
+        createHash: () => ({
+          update: () => ({
+            digest: () => '00001111'
+          })
+        })
+      }
+    })
+  });
+
+  it('should use external x11 for block header hash', () => {
+    const blockHeader = new BlockHeader(headerBuffer);
+    expect(blockHeader.hash).to.equal('0000000cc55c08ed64afb41c7c2f382a64901eadfcc6663c4e70987fdc0e8401')
+  })
+
+  it('should use external crypto module', () => {
+    const hash = Hash.sha512(Buffer.alloc(32));
+    expect(hash).to.equal('00001111')
+  })
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
The feature adds the ability to externally configure crypto engines for dashcore-lib.
It is required for `wasm-x11-hash` because wasm builds are loading asynchronously, and it is not possible to replace synchronous `x11-hash-js` with async `wasm-x11-hash` 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## What was done?
Exposed `configure` function for `crypto` and `x11` libraries

<!--- Describe your changes in detail -->

## How Has This Been Tested?
Added unit test

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
