### PR TITLE
fix: ripemd160 is omitted in Node 18

### DIFF
--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -6,6 +6,7 @@
 const { configuration } = require('../configuration');
 var BufferUtil = require('../util/buffer');
 var $ = require('../util/preconditions');
+var RipeMd160 = require('ripemd160');
 
 var Hash = module.exports;
 
@@ -36,7 +37,7 @@ Hash.x11 = function (buf) {
 
 Hash.ripemd160 = function (buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return configuration.crypto.createHash('ripemd160').update(buf).digest();
+  return new RipeMd160().update(buf).digest();
 };
 
 Hash.sha256ripemd160 = function (buf) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint-config-prettier": "^8.3.0",
         "inherits": "=2.0.1",
         "lodash": "^4.17.20",
+        "ripemd160": "^2.0.2",
         "unorm": "^1.6.0"
       },
       "devDependencies": {
@@ -3580,7 +3581,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -3593,8 +3593,7 @@
     "node_modules/hash-base/node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
@@ -6325,7 +6324,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -6338,8 +6336,7 @@
     "node_modules/readable-stream/node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -6483,7 +6480,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "dev": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -6945,7 +6941,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -7535,8 +7530,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/util/node_modules/inherits": {
       "version": "2.0.4",
@@ -11009,7 +11003,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -11019,8 +11012,7 @@
         "inherits": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         }
       }
     },
@@ -13088,7 +13080,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -13098,8 +13089,7 @@
         "inherits": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         }
       }
     },
@@ -13208,7 +13198,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -13600,7 +13589,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -14080,8 +14068,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "eslint-config-prettier": "^8.3.0",
     "inherits": "=2.0.1",
     "lodash": "^4.17.20",
+    "ripemd160": "^2.0.2",
     "unorm": "^1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Explicitly updates `dashcore-lib` to use the native-javascript `ripemd160` module, even for node.

## Issue being fixed or feature implemented

`ripemd160` is a known-insecure algorithm. It's been omitted from `libssl3`, and therefore removed as of `node-v18`.

Since we have no upgrade path to use a more secure algorithm, we must use the same ripemd160 implementation that we were already using in the browser in node as well.

See also: https://github.com/dashhive/crowdnode-cli/issues/18

## What was done?

We're already using [`ripemd160`](https://github.com/crypto-browserify/ripemd160). It already uses the same node-like API that we're using. All we need to do is switch to using it explicitly for node rather than just implicitly for the browser.

```txt
dashcore-lib
    => crypto-browserify
        => create-hash
            => ripemd160
```

## How Has This Been Tested?

It was already there and working all along.

```js
var RipeMd160 = require('ripemd160');

var buf = Buffer.from('hello\x86\uffff', 'utf8');

var hash = new RipeMd160().update(buf).digest();
// <Buffer af 71 b3 c7 d2 46 60 cc 5b 2d 8f a9 2a 64 8e 65 98 b1 2c 25>
```

```js
crypto.createHash('ripemd160').update(buf).digest();
// <Buffer af 71 b3 c7 d2 46 60 cc 5b 2d 8f a9 2a 64 8e 65 98 b1 2c 25>
```

## Breaking Changes

None.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~ N/A
- [x] ~~I have added or updated relevant unit/integration/functional/e2e tests~~ N/A
- [x] ~~I have made corresponding changes to the documentation~~ N/A
