### PR TITLE
fix: vulnerability in elliptic library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "^12.12.47",
         "bloom-filter": "^0.2.0",
         "bls-signatures": "^0.2.5",
-        "bn.js": "=4.11.8",
+        "bn.js": "^4.12.0",
         "bs58": "=4.0.1",
         "elliptic": "^6.5.4",
         "eslint-config-prettier": "^8.3.0",
@@ -1326,9 +1326,9 @@
       "integrity": "sha512-5TzQNCtR4zWE4lM08EOMIT8l3b4h8g5LNKu50fUYP1PnupaLGSLklAcTto4lnH7VXpyhsar+74L9wNJII4E/4Q=="
     },
     "node_modules/bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/body-parser": {
       "version": "1.19.0",
@@ -1461,9 +1461,9 @@
       }
     },
     "node_modules/browserify-rsa/node_modules/bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
       "dev": true
     },
     "node_modules/browserify-sign": {
@@ -1484,9 +1484,9 @@
       }
     },
     "node_modules/browserify-sign/node_modules/bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
       "dev": true
     },
     "node_modules/browserify-sign/node_modules/inherits": {
@@ -1721,10 +1721,16 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -2306,11 +2312,6 @@
         "minimalistic-assert": "^1.0.1",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/elliptic/node_modules/inherits": {
       "version": "2.0.4",
@@ -4498,9 +4499,9 @@
       "dev": true
     },
     "node_modules/karma": {
-      "version": "6.3.19",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.19.tgz",
-      "integrity": "sha512-NDhWckzES/Y9xMiddyU1RzaKL76/scCsu8Mp0vR0Z3lQRvC3p72+Ab4ppoxs36S9tyPNX5V48yvaV++RNEBPZw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.0.tgz",
+      "integrity": "sha512-s8m7z0IF5g/bS5ONT7wsOavhW4i4aFkzD4u4wgzAQWT4HGUeWI3i21cK2Yz6jndMAeHETp5XuNsRoyGJZXVd4w==",
       "dev": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
@@ -4609,7 +4610,7 @@
     "node_modules/karma-mocha-reporter": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/karma-mocha-reporter/-/karma-mocha-reporter-2.2.5.tgz",
-      "integrity": "sha1-FRIAlejtgZGG5HoLAS8810GJVWA=",
+      "integrity": "sha512-Hr6nhkIp0GIJJrvzY8JFeHpQZNseuIakGac4bpw8K1+5F0tLb6l7uvXRa8mt2Z+NVwYgCct4QAfp2R2QP6o00w==",
       "dev": true,
       "dependencies": {
         "chalk": "^2.1.0",
@@ -9186,9 +9187,9 @@
       "integrity": "sha512-5TzQNCtR4zWE4lM08EOMIT8l3b4h8g5LNKu50fUYP1PnupaLGSLklAcTto4lnH7VXpyhsar+74L9wNJII4E/4Q=="
     },
     "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -9314,9 +9315,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
           "dev": true
         }
       }
@@ -9339,9 +9340,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
           "dev": true
         },
         "inherits": {
@@ -9513,9 +9514,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
@@ -10034,11 +10035,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
         "inherits": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -11686,9 +11682,9 @@
       "dev": true
     },
     "karma": {
-      "version": "6.3.19",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.19.tgz",
-      "integrity": "sha512-NDhWckzES/Y9xMiddyU1RzaKL76/scCsu8Mp0vR0Z3lQRvC3p72+Ab4ppoxs36S9tyPNX5V48yvaV++RNEBPZw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.0.tgz",
+      "integrity": "sha512-s8m7z0IF5g/bS5ONT7wsOavhW4i4aFkzD4u4wgzAQWT4HGUeWI3i21cK2Yz6jndMAeHETp5XuNsRoyGJZXVd4w==",
       "dev": true,
       "requires": {
         "@colors/colors": "1.5.0",
@@ -11797,7 +11793,7 @@
     "karma-mocha-reporter": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/karma-mocha-reporter/-/karma-mocha-reporter-2.2.5.tgz",
-      "integrity": "sha1-FRIAlejtgZGG5HoLAS8810GJVWA=",
+      "integrity": "sha512-Hr6nhkIp0GIJJrvzY8JFeHpQZNseuIakGac4bpw8K1+5F0tLb6l7uvXRa8mt2Z+NVwYgCct4QAfp2R2QP6o00w==",
       "dev": true,
       "requires": {
         "chalk": "^2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "bls-signatures": "^0.2.5",
         "bn.js": "=4.11.8",
         "bs58": "=4.0.1",
-        "elliptic": "6.5.3",
+        "elliptic": "^6.5.4",
         "eslint-config-prettier": "^8.3.0",
         "inherits": "=2.0.1",
         "lodash": "^4.17.20",
@@ -2294,18 +2294,28 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dependencies": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/elliptic/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -10011,17 +10021,29 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
       }
     },
     "emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@types/node": "^12.12.47",
     "bloom-filter": "^0.2.0",
     "bls-signatures": "^0.2.5",
-    "bn.js": "=4.11.8",
+    "bn.js": "^4.12.0",
     "bs58": "=4.0.1",
     "elliptic": "^6.5.4",
     "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "bls-signatures": "^0.2.5",
     "bn.js": "=4.11.8",
     "bs58": "=4.0.1",
-    "elliptic": "6.5.3",
+    "elliptic": "^6.5.4",
     "eslint-config-prettier": "^8.3.0",
     "inherits": "=2.0.1",
     "lodash": "^4.17.20",

--- a/test/crypto/ecdsa.js
+++ b/test/crypto/ecdsa.js
@@ -326,6 +326,10 @@ describe('ECDSA', function () {
       it('should verify a valid signature, and unverify an invalid signature', function () {
         var sig = ECDSA.sign(ecdsa.hashbuf, ecdsa.privkey);
         ECDSA.verify(ecdsa.hashbuf, sig, ecdsa.pubkey).should.equal(true);
+        // TODO -- the test is supposed to fail, and does fail, but not in
+        //         the desired manner - because the signature doesn't generate
+        //         a valid public key and therefore fails on a toPubKey(),
+        //         rather that giving a bogus r and s and failing at a later stage
         var fakesig = new Signature(sig.r.add(new BN(1)), sig.s);
         ECDSA.verify(ecdsa.hashbuf, fakesig, ecdsa.pubkey).should.equal(false);
       });

--- a/test/crypto/ecdsa.js
+++ b/test/crypto/ecdsa.js
@@ -323,14 +323,13 @@ describe('ECDSA', function () {
         ecdsa.signRandomK();
         ecdsa.verify().verified.should.equal(true);
       });
-      it('should verify a valid signature, and unverify an invalid signature', function () {
+      it('should verify a valid signature', function () {
         var sig = ECDSA.sign(ecdsa.hashbuf, ecdsa.privkey);
         ECDSA.verify(ecdsa.hashbuf, sig, ecdsa.pubkey).should.equal(true);
-        // TODO -- the test is supposed to fail, and does fail, but not in
-        //         the desired manner - because the signature doesn't generate
-        //         a valid public key and therefore fails on a toPubKey(),
-        //         rather that giving a bogus r and s and failing at a later stage
-        var fakesig = new Signature(sig.r.add(new BN(1)), sig.s);
+      });
+      it('should not verify an invalid signature', function () {
+        var fakehashbuf = Hash.sha256(Buffer.from('some other data'));
+        var fakesig = ECDSA.sign(fakehashbuf, ecdsa.privkey);
         ECDSA.verify(ecdsa.hashbuf, fakesig, ecdsa.pubkey).should.equal(false);
       });
       it('should work with big and little endian', function () {


### PR DESCRIPTION
npm is scaring our crowdnode-cli users with scary messages, such as:

```bash
npm install --location=global crowdnode-cli
```

```txt
changed 110 packages, and audited 111 packages in 4s

14 packages are looking for funding
  run `npm fund` for details

3 moderate severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
```

## Issue being fixed or feature implemented

The `package.json` was accidentally locked to the vulnerable version.

The fixed version has a single check as the change:

https://github.com/indutny/elliptic/commit/441b7428b0e8f6636c42118ad2aaa186d3c34c3f

## What was done?

- Unlock `elliptic` to non-breaking change versions.
- Fix the test that was broken, but obscured by the buggy elliptic behavior (was testing the signature incorrectly)
- Unlock `bn.js` to agree with elliptic in the browser.

## How Has This Been Tested?

By the `elliptic` team:

https://github.com/indutny/elliptic/commits/master

## Breaking Changes

Won't allow attackers to gain access to private keys through timing attacks anymore. 😢

## Checklist:

- [x] I have performed a self-review of my own code
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~ N/A
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] ~~I have made corresponding changes to the documentation~~ N/A
