### PR TITLE
fix: adds missing item to QuorumEntry (porting v20 changes additions)

### DIFF
--- a/lib/deterministicmnlist/QuorumEntry.js
+++ b/lib/deterministicmnlist/QuorumEntry.js
@@ -362,6 +362,11 @@ QuorumEntry.getParams = function getParams(llmqType) {
       params.threshold = 67;
       params.maximumActiveQuorumsCount = 24;
       return params;
+    case constants.LLMQ_TYPES.LLMQ_TYPE_25_67:
+      params.size = 25;
+      params.threshold = 67;
+      params.maximumActiveQuorumsCount = 24;
+      return params;
     case constants.LLMQ_TYPES.LLMQ_TYPE_LLMQ_TEST:
       params.size = 3;
       params.threshold = 2;


### PR DESCRIPTION
## Issue being fixed or feature implemented
It fixes this issue:
```
dashpay/insight:4.0.1 release is bad, rolling back to dashpay/insight:4.0.0, error from insight on crashing is:

[2023-03-24T06:50:35.399Z] error: uncaught exception: Error: Invalid llmq type 6
    at Function.getParams (/insight/node_modules/@dashevo/dashcore-lib/lib/deterministicmnlist/QuorumEntry.js:406:13)
    at Function.fromBuffer (/insight/node_modules/@dashevo/dashcore-lib/lib/transaction/payload/commitmenttxpayload.js:95:42)
    at Object.parsePayloadBuffer [as parseBuffer] (/insight/node_modules/@dashevo/dashcore-lib/lib/transaction/payload/payload.js:63:18)
    at Transaction.fromBufferReader (/insight/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:404:36)
    at Function._fromBufferReader (/insight/node_modules/@dashevo/dashcore-lib/lib/block/block.js:92:42)
    at Function.fromBufferReader (/insight/node_modules/@dashevo/dashcore-lib/lib/block/block.js:103:22)
    at Function.fromBuffer (/insight/node_modules/@dashevo/dashcore-lib/lib/block/block.js:112:16)
    at Function.fromString (/insight/node_modules/@dashevo/dashcore-lib/lib/block/block.js:121:16)
    at /insight/lib/services/dashd.js:1911:41
    at newCallback (/insight/node_modules/@dashevo/dashd-rpc/lib/index.js:58:16)
[2023-03-24T06:50:35.400Z] error: Error: Invalid llmq type 6
    at Function.getParams (/insight/node_modules/@dashevo/dashcore-lib/lib/deterministicmnlist/QuorumEntry.js:406:13)
    at Function.fromBuffer (/insight/node_modules/@dashevo/dashcore-lib/lib/transaction/payload/commitmenttxpayload.js:95:42)
    at Object.parsePayloadBuffer [as parseBuffer] (/insight/node_modules/@dashevo/dashcore-lib/lib/transaction/payload/payload.js:63:18)
    at Transaction.fromBufferReader (/insight/node_modules/@dashevo/dashcore-lib/lib/transaction/transaction.js:404:36)
    at Function._fromBufferReader (/insight/node_modules/@dashevo/dashcore-lib/lib/block/block.js:92:42)
    at Function.fromBufferReader (/insight/node_modules/@dashevo/dashcore-lib/lib/block/block.js:103:22)
    at Function.fromBuffer (/insight/node_modules/@dashevo/dashcore-lib/lib/block/block.js:112:16)
    at Function.fromString (/insight/node_modules/@dashevo/dashcore-lib/lib/block/block.js:121:16)
    at /insight/lib/services/dashd.js:1911:41
    at newCallback (/insight/node_modules/@dashevo/dashd-rpc/lib/index.js:58:16)
```

## What was done
this type is introduced lately:

```
    LLMQ_25_67 = 6, // 25 members, 67 (67%) threshold, one per hour
```

and already supported by newest dashcore-lib, seems so: https://github.com/dashpay/dashcore-lib/blob/master/lib/constants/index.js#L67
But this file `lib/deterministicmnlist/QuorumEntry.js` doesn't have it in switch() conditions:

```
case constants.LLMQ_TYPES.LLMQ_TYPE_50_60:
... many others but missing LLMQ_TYPE_25_67## What was done?
```


## Checklist:
- [x] I have performed a self-review of my own code
