### PR TITLE
fix: wrong rotated quorum type

### DIFF
--- a/lib/deterministicmnlist/SimplifiedMNList.js
+++ b/lib/deterministicmnlist/SimplifiedMNList.js
@@ -538,7 +538,7 @@ SimplifiedMNList.prototype.isLLMQTypeRotated =
   function isLLMQTypeRotated(llmq) {
     return llmq === constants.LLMQ_TYPES.LLMQ_DEVNET_DIP0024 ||
       llmq === constants.LLMQ_TYPES.LLMQ_TYPE_TEST_DIP0024 ||
-      llmq === constants.LLMQ_TYPES.LLMQ_TYPE_25_67;
+      llmq === constants.LLMQ_TYPES.LLMQ_TYPE_60_75;
   };
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We use testnet/mainnet llmq type 6 for rotated quorums, but it must be 5
## What was done?

<!--- Describe your changes in detail -->
Rotated quorum type was changed from 6 to 5 for the testnet/mainnet

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests
## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
