### PR TITLE
fix: instant lock version higher than 1 is not supported

### DIFF
--- a/lib/instantlock/instantlock.js
+++ b/lib/instantlock/instantlock.js
@@ -75,7 +75,7 @@ class InstantLock {
       signature,
     };
 
-    if (version === 1) {
+    if (version >= 1) {
       result.version = version;
       result.cyclehash = cyclehash;
     }
@@ -406,7 +406,7 @@ class InstantLock {
       signature: this.signature.toString('hex'),
     };
 
-    if (this.version === 1) {
+    if (this.version >= 1) {
       result.version = this.version;
       result.cyclehash = this.cyclehash;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Instant Lock logic for version 1 and higher is enabled strictly for version 1


## What was done?

<!--- Describe your changes in detail -->
- Fixed version conditions

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes

<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
